### PR TITLE
Ollama: Use no json format when creating the search query

### DIFF
--- a/scrapegraphai/nodes/search_internet_node.py
+++ b/scrapegraphai/nodes/search_internet_node.py
@@ -10,6 +10,7 @@ from langchain.prompts import PromptTemplate
 from ..utils.logging import get_logger
 from ..utils.research_web import search_on_web
 from .base_node import BaseNode
+from ..models import Ollama
 
 
 class SearchInternetNode(BaseNode):
@@ -94,7 +95,14 @@ class SearchInternetNode(BaseNode):
 
         # Execute the chain to get the search query
         search_answer = search_prompt | self.llm_model | output_parser
-        search_query = search_answer.invoke({"user_prompt": user_prompt})[0]
+        
+        # Ollama: Use no json format when creating the search query
+        if isinstance(self.llm_model, Ollama) and self.llm_model.format == 'json':
+            self.llm_model.format = None
+            search_query = search_answer.invoke({"user_prompt": user_prompt})[0]
+            self.llm_model.format = 'json'
+        else:
+            search_query = search_answer.invoke({"user_prompt": user_prompt})[0]
 
         self.logger.info(f"Search Query: {search_query}")
 


### PR DESCRIPTION
Fix for issue https://github.com/ScrapeGraphAI/Scrapegraph-ai/issues/433

I did consider other options but found this to be the most clean option. 
(E.g. you could modify the base Ollama class and add a calling function to not use JSON or something)