### PR TITLE
feat: add support for firecrawl

### DIFF
--- a/examples/firecrawl/README.md
+++ b/examples/firecrawl/README.md
@@ -1,0 +1,9 @@
+# Using Firecrawl as scraping backend
+1. Specify your FIRECRAWL_API_KEY in `.env.example`.
+2. When self hosting Firecrawl, specify your FIRECRAWL_API_URL in `.env.example` . Example: http://localhost:3002.
+When self-hosting, no API key is needed.
+3. Rename `.env.example` to `.env`.
+4. Run one of the scripts in this example folder.
+
+## Self-hosting Firecrawl
+Follow the tutorial described in the repository https://github.com/mendableai/firecrawl. 

--- a/examples/firecrawl/search_graph_firecrawl.py
+++ b/examples/firecrawl/search_graph_firecrawl.py
@@ -1,0 +1,51 @@
+"""
+Example of Search Graph
+"""
+
+import os
+from dotenv import load_dotenv
+from scrapegraphai.graphs import SearchGraph
+
+load_dotenv()
+FIRECRAWL_API_URL = os.getenv("FIRECRAWL_API_URL")
+FIRECRAWL_API_KEY = os.getenv("FIRECRAWL_API_KEY")
+
+if FIRECRAWL_API_URL is not None:
+    os.environ['FIRECRAWL_API_URL'] = FIRECRAWL_API_URL
+if FIRECRAWL_API_KEY is not None:
+    os.environ['FIRECRAWL_API_KEY'] = FIRECRAWL_API_KEY
+
+# ************************************************
+# Define the configuration for the graph
+# ************************************************
+
+graph_config = {
+     "llm": {
+        "model": "ollama/mistral",
+        "temperature": 0,
+        "format": "json",  # Ollama needs the format to be specified explicitly
+        "base_url": "http://localhost:11434",  # set Ollama URL
+    },
+    "embeddings": {
+        "model": "ollama/nomic-embed-text",
+        "base_url": "http://localhost:11434",  # set ollama URL arbitrarily
+    },
+    "max_results": 2,
+    "verbose": True,
+    "headless":True,
+    "loader_kwargs": {
+        'scraping_backend': 'firecrawl'
+    },
+}
+
+# ************************************************
+# Create the SearchGraph instance and run it
+# ************************************************
+
+search_graph = SearchGraph(
+    prompt="List me Chioggia's famous dishes",
+    config=graph_config
+)
+
+result = search_graph.run()
+print(result)

--- a/examples/firecrawl/search_graph_schema_firecrawl.py
+++ b/examples/firecrawl/search_graph_schema_firecrawl.py
@@ -1,0 +1,81 @@
+"""
+Example of Search Graph
+"""
+import os
+
+from dotenv import load_dotenv
+from scrapegraphai.graphs import SearchGraph
+from scrapegraphai.utils import convert_to_csv, convert_to_json, prettify_exec_info
+
+from pydantic import BaseModel, Field
+from typing import List
+
+
+# Load environment variables
+load_dotenv()
+FIRECRAWL_API_URL = os.getenv("FIRECRAWL_API_URL")
+FIRECRAWL_API_KEY = os.getenv("FIRECRAWL_API_KEY")
+
+if FIRECRAWL_API_URL is not None:
+    os.environ['FIRECRAWL_API_URL'] = FIRECRAWL_API_URL
+if FIRECRAWL_API_KEY is not None:
+    os.environ['FIRECRAWL_API_KEY'] = FIRECRAWL_API_KEY
+
+
+# ************************************************
+# Define the output schema for the graph
+# ************************************************
+
+class Dish(BaseModel):
+    name: str = Field(description="The name of the dish")
+    description: str = Field(description="The description of the dish")
+
+class Dishes(BaseModel):
+    dishes: List[Dish]
+
+# ************************************************
+# Define the configuration for the graph
+# ************************************************
+
+graph_config = {
+     "llm": {
+        "model": "ollama/mistral",
+        "temperature": 0,
+        "format": "json",  # Ollama needs the format to be specified explicitly
+        "base_url": "http://localhost:11434",  # set Ollama URL
+    },
+    "embeddings": {
+        "model": "ollama/nomic-embed-text",
+        "base_url": "http://localhost:11434",  # set ollama URL arbitrarily
+    },
+    "max_results": 2,
+    "verbose": True,
+    "headless":True,
+    "loader_kwargs": {
+        'scraping_backend': 'firecrawl'
+    },
+}
+
+# ************************************************
+# Create the SearchGraph instance and run it
+# ************************************************
+
+search_graph = SearchGraph(
+    prompt="List me Chioggia's famous dishes",
+    config=graph_config,
+    schema=Dishes
+)
+
+result = search_graph.run()
+print(result)
+
+# ************************************************
+# Get graph execution info
+# ************************************************
+
+graph_exec_info = search_graph.get_execution_info()
+print(prettify_exec_info(graph_exec_info))
+
+# Save to json and csv
+convert_to_csv(result, "result")
+convert_to_json(result, "result")

--- a/examples/firecrawl/search_link_graph_firecrawl.py
+++ b/examples/firecrawl/search_link_graph_firecrawl.py
@@ -1,0 +1,64 @@
+"""
+Example of Search Graph
+"""
+import os
+from dotenv import load_dotenv
+from scrapegraphai.graphs import SearchGraph
+from scrapegraphai.utils import convert_to_csv, convert_to_json, prettify_exec_info
+
+load_dotenv()
+FIRECRAWL_API_URL = os.getenv("FIRECRAWL_API_URLs")
+FIRECRAWL_API_KEY = os.getenv("FIRECRAWL_API_KEY")
+
+if FIRECRAWL_API_URL is not None:
+    os.environ['FIRECRAWL_API_URL'] = FIRECRAWL_API_URL
+if FIRECRAWL_API_KEY is not None:
+    os.environ['FIRECRAWL_API_KEY'] = FIRECRAWL_API_KEY
+
+
+# ************************************************
+# Define the configuration for the graph
+# ************************************************
+
+graph_config = {
+     "llm": {
+        "model": "ollama/mistral",
+        "temperature": 0,
+        "format": "json",  # Ollama needs the format to be specified explicitly
+        "base_url": "http://localhost:11434",  # set Ollama URL
+    },
+    "embeddings": {
+        "model": "ollama/nomic-embed-text",
+        "base_url": "http://localhost:11434",  # set ollama URL arbitrarily
+    },
+    "max_results": 2,
+    "verbose": True,
+    "headless":True,
+    "loader_kwargs": {
+        'scraping_backend': 'firecrawl'
+    },
+}
+
+
+# ************************************************
+# Create the SearchGraph instance and run it
+# ************************************************
+
+search_graph = SearchGraph(
+    prompt="List me the best escursions near Trento",
+    config=graph_config
+)
+
+result = search_graph.run()
+print(result)
+
+# ************************************************
+# Get graph execution info
+# ************************************************
+
+graph_exec_info = search_graph.get_execution_info()
+print(prettify_exec_info(graph_exec_info))
+
+# Save to json and csv
+convert_to_csv(result, "result")
+convert_to_json(result, "result")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,9 @@ dependencies = [
     "undetected-playwright>=0.3.0",
     "semchunk>=1.0.1",
     "langchain-fireworks>=0.1.3",
-    "langchain-community>=0.2.9"
+    "langchain-community>=0.2.9",
+    "firecrawl-py>=0.0.2",
+
 ]
 
 license = "MIT"

--- a/scrapegraphai/docloaders/__init__.py
+++ b/scrapegraphai/docloaders/__init__.py
@@ -1,3 +1,4 @@
 """__init__.py file for docloaders folder"""
 
 from .chromium import ChromiumLoader
+from .firecrawl import FirecrawlLoader

--- a/scrapegraphai/docloaders/firecrawl.py
+++ b/scrapegraphai/docloaders/firecrawl.py
@@ -1,0 +1,81 @@
+from typing import Any, AsyncIterator, Iterator, List, Optional
+from langchain_community.document_loaders.base import BaseLoader
+from langchain_core.documents import Document
+from langchain_community.document_loaders import FireCrawlLoader
+
+class FirecrawlLoader(BaseLoader):
+    """Fetches HTML pages from URLs using FireCrawlLoader API
+
+    Attributes:
+        urls: A list of URLs to fetch content from.
+        mode: The mode for FireCrawlLoader, defaults to "scrape".
+        params: Additional parameters for FireCrawlLoader.
+    """
+
+    def __init__(
+        self,
+        urls: List[str],
+        *,
+        mode: str = "scrape",
+        params: Optional[dict] = None,
+        **kwargs: Any,
+    ):
+        """Initialize the loader with a list of URL paths.
+
+        Args:
+            urls: A list of URLs to fetch content from.
+            mode: The mode for FireCrawlLoader, defaults to "scrape".
+            params: Additional parameters for FireCrawlLoader.
+            kwargs: Additional keyword arguments (unused, for compatibility).
+        """
+        self.urls = urls
+        self.mode = mode
+        # Only fetch main content, no headers, footers, etc.
+        self.params = params or {"onlyMainContent": True} 
+        print('Using FireCrawlLoader')
+
+    def lazy_load(self) -> Iterator[Document]:
+        """
+        Lazily load content from the provided URLs using FireCrawlLoader.
+
+        This method yields Documents one at a time as they're fetched,
+        instead of waiting to fetch all URLs before returning.
+
+        Yields:
+            Document: The fetched content encapsulated within a Document object.
+        """
+        for url in self.urls:
+            loader = FireCrawlLoader(url=url, mode=self.mode, params=self.params)
+            docs = loader.load()
+            
+            if docs:
+                # Assuming FireCrawlLoader returns a list with at least one Document
+                doc = docs[0]
+                # Reformat the document to fit scrapegraphai's Document format
+                content = f"Title: {doc.metadata.get('title', '')}\nDescription: {doc.metadata.get('description', '')}"
+                metadata = {'source': url}
+                yield Document(page_content=content, metadata=metadata)
+
+    async def alazy_load(self) -> AsyncIterator[Document]:
+        """
+        Asynchronously load content from the provided URLs.
+
+        This method mimics the async behavior of the original ChromiumLoader,
+        but since FireCrawlLoader doesn't have an async API, it falls back to
+        using the synchronous lazy_load method.
+
+        Yields:
+            Document: A Document object containing the fetched content, along with its
+            source URL as metadata.
+        """
+        for document in self.lazy_load():
+            yield document
+
+    def load(self) -> List[Document]:
+        """
+        Load all documents from the provided URLs.
+
+        Returns:
+            List[Document]: A list of Document objects containing the fetched content.
+        """
+        return list(self.lazy_load())


### PR DESCRIPTION
Linking https://github.com/ScrapeGraphAI/Scrapegraph-ai/issues/493.
This is only the basic functionality which adapts the Search Node to be able to use the firecrawl instead of plain playwright for the web search.

Can you please check that the pyproject.toml is correct? I only added the library as requirement. I think you still have to "build" it in order to appear in requirements.txt?

I also added some examples in examples/firecrawl