### PR TITLE
Graph Builder failed import bugfix

### DIFF
--- a/scrapegraphai/builders/graph_builder.py
+++ b/scrapegraphai/builders/graph_builder.py
@@ -4,9 +4,11 @@ GraphBuilder Module
 
 from langchain_core.prompts import ChatPromptTemplate
 from langchain.chains import create_extraction_chain
-from ..models import Gemini
-from ..helpers import nodes_metadata, graph_schema
+from langchain_community.chat_models import ErnieBotChat
+from langchain_google_genai import ChatGoogleGenerativeAI
 from langchain_openai import ChatOpenAI
+
+from ..helpers import nodes_metadata, graph_schema
 
 class GraphBuilder:
     """
@@ -72,9 +74,9 @@ class GraphBuilder:
         if "gpt-" in llm_params["model"]:
             return ChatOpenAI(llm_params)
         elif "gemini" in llm_params["model"]:
-            return Gemini(llm_params)
+            return ChatGoogleGenerativeAI(llm_params)
         elif "ernie" in llm_params["model"]:
-            return Ernie(llm_params)
+            return ErnieBotChat(llm_params)
         raise ValueError("Model not supported")
 
     def _generate_nodes_description(self):


### PR DESCRIPTION
Tried to run graph_builder from the Google Colab examples but failed to import GraphBuilder.

Issues:
1. scrapegraphai/models/__init__.py no longer has a model named Gemini.
2. Ernie was referenced but never imported.

Solutions:
1. Continuing the work by Marco Vinciguerra on [this commit](https://github.com/ScrapeGraphAI/Scrapegraph-ai/commit/203ee2c1862a12a399dac1f278a0d90ffdcd9e80), changed the imports to langchain models.
2. Minor fix of imports ordering to match rest of code (local repo imports last with space either side)

Checks:
1. Checked that both langchain_community and langchain_google_genai were already used and available.
2. Checked code could run without error
3. Linting and formatting matched

Further suggestions for future edits:
1. move imports down to within the if/else statements to minimize the amount of packages required but left unused.
2. create a whole control mechanism to abstract the specific model and it's packages/imports away so users can select the model(s) to be used and install them - excluding those they don't need.