### PR TITLE
Remove provider string from state

### DIFF
--- a/scrapegraphai/nodes/generate_answer_from_image_node.py
+++ b/scrapegraphai/nodes/generate_answer_from_image_node.py
@@ -69,7 +69,8 @@ class GenerateAnswerFromImageNode(BaseNode):
         self.logger.info(f"--- Executing {self.node_name} Node ---")
 
         images = state.get('screenshots', [])
-        analyses = []
+        # remove the provider key from the state
+        self.node_config["config"]["llm"]["model"] = self.node_config["config"]["llm"]["model"].replace('openai/', '')
 
         supported_models = ("gpt-4o", "gpt-4o-mini", "gpt-4-turbo")
 


### PR DESCRIPTION
After the update of adding the `provider` to the model, the ScreenshotScraperGraph using openai fails with this message 

"ValueError: Model 'openai/gpt-4o-mini' is not supported". 

It seems we're sending the provider prefix to the API endpoint. This code strips that out of the state before making the request