### PR TITLE
fix: deepcopy fail for coping model_instance config

### DIFF
--- a/scrapegraphai/graphs/csv_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/csv_scraper_multi_graph.py
@@ -2,9 +2,10 @@
 CSVScraperMultiGraph Module
 """
 
-from copy import copy, deepcopy
 from typing import List, Optional
 from pydantic import BaseModel
+
+
 from .base_graph import BaseGraph
 from .abstract_graph import AbstractGraph
 from .csv_scraper_graph import CSVScraperGraph
@@ -12,6 +13,7 @@ from ..nodes import (
     GraphIteratorNode,
     MergeAnswersNode
 )
+from ..utils.copy import safe_deepcopy
 
 class CSVScraperMultiGraph(AbstractGraph):
     """ 
@@ -46,10 +48,7 @@ class CSVScraperMultiGraph(AbstractGraph):
 
         self.max_results = config.get("max_results", 3)
 
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
+        self.copy_config = safe_deepcopy(config)
 
         super().__init__(prompt, config, source, schema)
 

--- a/scrapegraphai/graphs/json_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/json_scraper_multi_graph.py
@@ -2,9 +2,10 @@
 JSONScraperMultiGraph Module
 """
 
-from copy import copy, deepcopy
+from copy import deepcopy
 from typing import List, Optional
 from pydantic import BaseModel
+
 from .base_graph import BaseGraph
 from .abstract_graph import AbstractGraph
 from .json_scraper_graph import JSONScraperGraph
@@ -12,6 +13,7 @@ from ..nodes import (
     GraphIteratorNode,
     MergeAnswersNode
 )
+from ..utils.copy import safe_deepcopy
 
 class JSONScraperMultiGraph(AbstractGraph):
     """ 
@@ -45,10 +47,7 @@ class JSONScraperMultiGraph(AbstractGraph):
 
         self.max_results = config.get("max_results", 3)
 
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
+        self.copy_config = safe_deepcopy(config)
 
         self.copy_schema = deepcopy(schema)
 

--- a/scrapegraphai/graphs/markdown_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/markdown_scraper_multi_graph.py
@@ -12,6 +12,7 @@ from ..nodes import (
     GraphIteratorNode,
     MergeAnswersNode
 )
+from ..utils.copy import safe_deepcopy
 
 class MDScraperMultiGraph(AbstractGraph):
     """
@@ -42,11 +43,7 @@ class MDScraperMultiGraph(AbstractGraph):
     """
 
     def __init__(self, prompt: str, source: List[str], config: dict, schema: Optional[BaseModel] = None):
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
-
+        self.copy_config = safe_deepcopy(config)
         self.copy_schema = deepcopy(schema)
 
         super().__init__(prompt, config, source, schema)

--- a/scrapegraphai/graphs/omni_search_graph.py
+++ b/scrapegraphai/graphs/omni_search_graph.py
@@ -2,7 +2,7 @@
 OmniSearchGraph Module
 """
 
-from copy import copy, deepcopy
+from copy import deepcopy
 from typing import Optional
 from pydantic import BaseModel
 
@@ -15,6 +15,7 @@ from ..nodes import (
     GraphIteratorNode,
     MergeAnswersNode
 )
+from ..utils.copy import safe_deepcopy
 
 
 class OmniSearchGraph(AbstractGraph):
@@ -48,10 +49,7 @@ class OmniSearchGraph(AbstractGraph):
 
         self.max_results = config.get("max_results", 3)
 
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
+        self.copy_config = safe_deepcopy(config)
 
         self.copy_schema = deepcopy(schema)
 

--- a/scrapegraphai/graphs/pdf_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/pdf_scraper_multi_graph.py
@@ -2,7 +2,7 @@
 PdfScraperMultiGraph Module
 """
 
-from copy import copy, deepcopy
+from copy import deepcopy
 from typing import List, Optional
 from pydantic import BaseModel
 from .base_graph import BaseGraph
@@ -12,6 +12,7 @@ from ..nodes import (
     GraphIteratorNode,
     MergeAnswersNode
 )
+from ..utils.copy import safe_deepcopy
 
 class PdfScraperMultiGraph(AbstractGraph):
     """ 
@@ -44,10 +45,7 @@ class PdfScraperMultiGraph(AbstractGraph):
     def __init__(self, prompt: str, source: List[str], 
                  config: dict, schema: Optional[BaseModel] = None):
 
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
+        self.copy_config = safe_deepcopy(config)
 
         self.copy_schema = deepcopy(schema)
 

--- a/scrapegraphai/graphs/script_creator_multi_graph.py
+++ b/scrapegraphai/graphs/script_creator_multi_graph.py
@@ -2,7 +2,6 @@
 ScriptCreatorMultiGraph Module
 """
 
-from copy import copy, deepcopy
 from typing import List, Optional
 
 from pydantic import BaseModel
@@ -15,6 +14,7 @@ from ..nodes import (
     GraphIteratorNode,
     MergeGeneratedScriptsNode
 )
+from ..utils.copy import safe_deepcopy
 
 class ScriptCreatorMultiGraph(AbstractGraph):
     """ 
@@ -47,10 +47,7 @@ class ScriptCreatorMultiGraph(AbstractGraph):
 
         self.max_results = config.get("max_results", 3)
 
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
+        self.copy_config = safe_deepcopy(config)
 
         super().__init__(prompt, config, source, schema)
 

--- a/scrapegraphai/graphs/search_graph.py
+++ b/scrapegraphai/graphs/search_graph.py
@@ -2,7 +2,7 @@
 SearchGraph Module
 """
 
-from copy import copy, deepcopy
+from copy import deepcopy
 from typing import Optional, List
 from pydantic import BaseModel
 
@@ -15,6 +15,7 @@ from ..nodes import (
     GraphIteratorNode,
     MergeAnswersNode
 )
+from ..utils.copy import safe_deepcopy
 
 class SearchGraph(AbstractGraph):
     """ 
@@ -47,10 +48,7 @@ class SearchGraph(AbstractGraph):
     def __init__(self, prompt: str, config: dict, schema: Optional[BaseModel] = None):
         self.max_results = config.get("max_results", 3)
 
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
+        self.copy_config = safe_deepcopy(config)
         self.copy_schema = deepcopy(schema)
         self.considered_urls = []  # New attribute to store URLs
 

--- a/scrapegraphai/graphs/smart_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/smart_scraper_multi_graph.py
@@ -2,7 +2,7 @@
 SmartScraperMultiGraph Module
 """
 
-from copy import copy, deepcopy
+from copy import deepcopy
 from typing import List, Optional
 from pydantic import BaseModel
 
@@ -14,6 +14,7 @@ from ..nodes import (
     GraphIteratorNode,
     MergeAnswersNode
 )
+from ..utils.copy import safe_deepcopy
 
 class SmartScraperMultiGraph(AbstractGraph):
     """ 
@@ -48,10 +49,7 @@ class SmartScraperMultiGraph(AbstractGraph):
 
         self.max_results = config.get("max_results", 3)
 
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
+        self.copy_config = safe_deepcopy(config)
 
         self.copy_schema = deepcopy(schema)
 

--- a/scrapegraphai/graphs/xml_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/xml_scraper_multi_graph.py
@@ -2,7 +2,7 @@
 XMLScraperMultiGraph Module
 """
 
-from copy import copy, deepcopy
+from copy import deepcopy
 from typing import List, Optional
 from pydantic import BaseModel
 
@@ -14,6 +14,7 @@ from ..nodes import (
     GraphIteratorNode,
     MergeAnswersNode
 )
+from ..utils.copy import safe_deepcopy
 
 class XMLScraperMultiGraph(AbstractGraph):
     """ 
@@ -46,10 +47,7 @@ class XMLScraperMultiGraph(AbstractGraph):
     def __init__(self, prompt: str, source: List[str], 
                  config: dict, schema: Optional[BaseModel] = None):
 
-        if all(isinstance(value, str) for value in config.values()):
-            self.copy_config = copy(config)
-        else:
-            self.copy_config = deepcopy(config)
+        self.copy_config = safe_deepcopy(config)
 
         self.copy_schema = deepcopy(schema)
 

--- a/scrapegraphai/utils/copy.py
+++ b/scrapegraphai/utils/copy.py
@@ -1,0 +1,78 @@
+import copy
+from typing import Any, Dict, Optional
+
+
+def safe_deepcopy(obj: Any, memo: Optional[Dict[int, Any]] = None) -> Any:
+    """
+    Attempts to create a deep copy of the object using `copy.deepcopy`
+    whenever possible. If that fails, it falls back to custom deep copy
+    logic or returns the original object.
+
+    Args:
+        obj (Any): The object to be copied, which can be of any type.
+        memo (Optional[Dict[int, Any]]): A dictionary used to track objects
+            that have already been copied to handle circular references.
+            If None, a new dictionary is created.
+
+    Returns:
+        Any: A deep copy of the object if possible; otherwise, a shallow
+        copy if deep copying fails; if neither is possible, the original
+        object is returned.
+    """
+
+    if memo is None:
+        memo = {}
+
+    if id(obj) in memo:
+        return memo[id(obj)]
+
+    try:
+        # Try to use copy.deepcopy first
+        return copy.deepcopy(obj, memo)
+    except (TypeError, AttributeError):
+        # If deepcopy fails, handle specific types manually
+
+        # Handle dictionaries
+        if isinstance(obj, dict):
+            new_obj = {}
+            memo[id(obj)] = new_obj
+            for k, v in obj.items():
+                new_obj[k] = safe_deepcopy(v, memo)
+            return new_obj
+
+        # Handle lists
+        elif isinstance(obj, list):
+            new_obj = []
+            memo[id(obj)] = new_obj
+            for v in obj:
+                new_obj.append(safe_deepcopy(v, memo))
+            return new_obj
+
+        # Handle tuples (immutable, but might contain mutable objects)
+        elif isinstance(obj, tuple):
+            new_obj = tuple(safe_deepcopy(v, memo) for v in obj)
+            memo[id(obj)] = new_obj
+            return new_obj
+
+        # Handle frozensets (immutable, but might contain mutable objects)
+        elif isinstance(obj, frozenset):
+            new_obj = frozenset(safe_deepcopy(v, memo) for v in obj)
+            memo[id(obj)] = new_obj
+            return new_obj
+
+        # Handle objects with attributes
+        elif hasattr(obj, "__dict__"):
+            new_obj = obj.__new__(obj.__class__)
+            for attr in obj.__dict__:
+                setattr(new_obj, attr, safe_deepcopy(getattr(obj, attr), memo))
+            memo[id(obj)] = new_obj
+            return new_obj
+
+        # Attempt shallow copy as a fallback
+        try:
+            return copy.copy(obj)
+        except (TypeError, AttributeError):
+            pass
+
+        # If all else fails, return the original object
+        return obj

--- a/scrapegraphai/utils/copy.py
+++ b/scrapegraphai/utils/copy.py
@@ -2,6 +2,9 @@ import copy
 from typing import Any, Dict, Optional
 from pydantic.v1 import BaseModel
 
+class DeepCopyError(Exception):
+    """Custom exception raised when an object cannot be deep-copied."""
+    pass
 
 def safe_deepcopy(obj: Any) -> Any:
     """
@@ -16,6 +19,8 @@ def safe_deepcopy(obj: Any) -> Any:
         Any: A deep copy of the object if possible; otherwise, a shallow
         copy if deep copying fails; if neither is possible, the original
         object is returned.
+    Raises:
+        DeepCopyError: If the object cannot be deep-copied or shallow-copied.
     """
 
     try:
@@ -70,4 +75,4 @@ def safe_deepcopy(obj: Any) -> Any:
         try:
             return copy.copy(obj)
         except (TypeError, AttributeError):
-            raise TypeError(f"Failed to create a deep copy obj") from e
+            raise DeepCopyError(f"Cannot deep copy the object of type {type(obj)}") from e

--- a/scrapegraphai/utils/copy.py
+++ b/scrapegraphai/utils/copy.py
@@ -1,8 +1,9 @@
 import copy
 from typing import Any, Dict, Optional
+from pydantic.v1 import BaseModel
 
 
-def safe_deepcopy(obj: Any, memo: Optional[Dict[int, Any]] = None) -> Any:
+def safe_deepcopy(obj: Any) -> Any:
     """
     Attempts to create a deep copy of the object using `copy.deepcopy`
     whenever possible. If that fails, it falls back to custom deep copy
@@ -10,9 +11,6 @@ def safe_deepcopy(obj: Any, memo: Optional[Dict[int, Any]] = None) -> Any:
 
     Args:
         obj (Any): The object to be copied, which can be of any type.
-        memo (Optional[Dict[int, Any]]): A dictionary used to track objects
-            that have already been copied to handle circular references.
-            If None, a new dictionary is created.
 
     Returns:
         Any: A deep copy of the object if possible; otherwise, a shallow
@@ -20,59 +18,56 @@ def safe_deepcopy(obj: Any, memo: Optional[Dict[int, Any]] = None) -> Any:
         object is returned.
     """
 
-    if memo is None:
-        memo = {}
-
-    if id(obj) in memo:
-        return memo[id(obj)]
-
     try:
+        
         # Try to use copy.deepcopy first
-        return copy.deepcopy(obj, memo)
-    except (TypeError, AttributeError):
+        if isinstance(obj,BaseModel):
+            # handle BaseModel because __fields_set__ need  compatibility 
+            copied_obj = obj.copy(deep=True)
+        else:
+            copied_obj = copy.deepcopy(obj)
+
+        return copied_obj
+    except (TypeError, AttributeError) as e:
         # If deepcopy fails, handle specific types manually
 
         # Handle dictionaries
         if isinstance(obj, dict):
             new_obj = {}
-            memo[id(obj)] = new_obj
+            
             for k, v in obj.items():
-                new_obj[k] = safe_deepcopy(v, memo)
+                new_obj[k] = safe_deepcopy(v)
             return new_obj
 
         # Handle lists
         elif isinstance(obj, list):
             new_obj = []
-            memo[id(obj)] = new_obj
+            
             for v in obj:
-                new_obj.append(safe_deepcopy(v, memo))
+                new_obj.append(safe_deepcopy(v))
             return new_obj
 
         # Handle tuples (immutable, but might contain mutable objects)
         elif isinstance(obj, tuple):
-            new_obj = tuple(safe_deepcopy(v, memo) for v in obj)
-            memo[id(obj)] = new_obj
+            new_obj = tuple(safe_deepcopy(v) for v in obj)
+            
             return new_obj
 
         # Handle frozensets (immutable, but might contain mutable objects)
         elif isinstance(obj, frozenset):
-            new_obj = frozenset(safe_deepcopy(v, memo) for v in obj)
-            memo[id(obj)] = new_obj
+            new_obj = frozenset(safe_deepcopy(v) for v in obj)
             return new_obj
 
         # Handle objects with attributes
         elif hasattr(obj, "__dict__"):
             new_obj = obj.__new__(obj.__class__)
             for attr in obj.__dict__:
-                setattr(new_obj, attr, safe_deepcopy(getattr(obj, attr), memo))
-            memo[id(obj)] = new_obj
+                setattr(new_obj, attr, safe_deepcopy(getattr(obj, attr)))
+            
             return new_obj
-
+        
         # Attempt shallow copy as a fallback
         try:
             return copy.copy(obj)
         except (TypeError, AttributeError):
-            pass
-
-        # If all else fails, return the original object
-        return obj
+            raise TypeError(f"Failed to create a deep copy obj") from e

--- a/tests/utils/copy_utils_test.py
+++ b/tests/utils/copy_utils_test.py
@@ -2,7 +2,7 @@ import copy
 import pytest
 
 # Assuming the custom_deepcopy function is imported or defined above this line
-from scrapegraphai.utils.copy import safe_deepcopy
+from scrapegraphai.utils.copy import DeepCopyError, safe_deepcopy
 from pydantic.v1 import BaseModel
 from pydantic import BaseModel as BaseModelV2
 
@@ -154,7 +154,7 @@ def test_deepcopy_object_without_dict():
     assert copy_obj_item is original_item
 
 def test_unhandled_type():
-    with pytest.raises(TypeError):
+    with pytest.raises(DeepCopyError):
         original = {"origin": NonCopyableObject(10)}
         copy_obj = safe_deepcopy(original)
 
@@ -162,7 +162,7 @@ def test_client():
     llm_instance_config = {
         "model": "moonshot-v1-8k",
         "base_url": "https://api.moonshot.cn/v1",
-        "api_key": "xxx",
+        "moonshot_api_key": "sk-OWo8hbSubp1QzOPyskOEwXQtZ867Ph0PZWCQdWrc3PH4o0lI",
     }
 
     from langchain_community.chat_models.moonshot import MoonshotChat

--- a/tests/utils/copy_utils_test.py
+++ b/tests/utils/copy_utils_test.py
@@ -4,12 +4,8 @@ import pytest
 # Assuming the custom_deepcopy function is imported or defined above this line
 from scrapegraphai.utils.copy import DeepCopyError, safe_deepcopy
 from pydantic.v1 import BaseModel
-from pydantic import BaseModel as BaseModelV2
 
 class PydantObject(BaseModel):
-    value: int
-
-class PydantObjectV2(BaseModelV2):
     value: int
 
 class NormalObject:
@@ -162,16 +158,16 @@ def test_client():
     llm_instance_config = {
         "model": "moonshot-v1-8k",
         "base_url": "https://api.moonshot.cn/v1",
-        "moonshot_api_key": "sk-OWo8hbSubp1QzOPyskOEwXQtZ867Ph0PZWCQdWrc3PH4o0lI",
+        "moonshot_api_key": "xxx",
     }
 
     from langchain_community.chat_models.moonshot import MoonshotChat
 
     llm_model_instance = MoonshotChat(**llm_instance_config)
-    
     copy_obj = safe_deepcopy(llm_model_instance)
+    
     assert copy_obj
-
+    assert hasattr(copy_obj, 'callbacks')
 
 def test_circular_reference_in_dict():
     original = {}
@@ -182,3 +178,9 @@ def test_circular_reference_in_dict():
     assert copy_obj is not original
     # Check that the circular reference is maintained in the copy
     assert copy_obj['self'] is copy_obj
+
+def test_with_pydantic():
+    original = PydantObject(value=1)
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj.value == original.value
+    assert copy_obj is not original 

--- a/tests/utils/copy_utils_test.py
+++ b/tests/utils/copy_utils_test.py
@@ -1,0 +1,170 @@
+import copy
+import pytest
+
+# Assuming the custom_deepcopy function is imported or defined above this line
+from scrapegraphai.utils.copy import safe_deepcopy
+
+
+class NormalObject:
+    def __init__(self, value):
+        self.value = value
+        self.nested = [1, 2, 3]
+
+    def __deepcopy__(self, memo):
+        raise TypeError("Forcing fallback")
+
+
+class NonDeepcopyable:
+    def __init__(self, value):
+        self.value = value
+
+    def __deepcopy__(self, memo):
+        raise TypeError("Forcing shallow copy fallback")
+
+
+class WithoutDict:
+    __slots__ = ["value"]
+
+    def __init__(self, value):
+        self.value = value
+
+    def __deepcopy__(self, memo):
+        raise TypeError("Forcing shallow copy fallback")
+
+    def __copy__(self):
+        return self
+
+
+class NonCopyableObject:
+    __slots__ = ["value"]
+
+    def __init__(self, value):
+        self.value = value
+
+    def __deepcopy__(self, memo):
+        raise TypeError("fail deep copy ")
+
+    def __copy__(self):
+        raise TypeError("fail shallow copy")
+
+
+def test_deepcopy_simple_dict():
+    original = {"a": 1, "b": 2, "c": [3, 4, 5]}
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj == original
+    assert copy_obj is not original
+    assert copy_obj["c"] is not original["c"]
+
+
+def test_deepcopy_simple_list():
+    original = [1, 2, 3, [4, 5]]
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj == original
+    assert copy_obj is not original
+    assert copy_obj[3] is not original[3]
+
+
+def test_deepcopy_with_tuple():
+    original = (1, 2, [3, 4])
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj == original
+    assert copy_obj is not original
+    assert copy_obj[2] is not original[2]
+
+
+def test_deepcopy_with_frozenset():
+    original = frozenset([1, 2, 3, (4, 5)])
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj == original
+    assert copy_obj is not original
+
+
+def test_deepcopy_with_object():
+    original = NormalObject(10)
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj.value == original.value
+    assert copy_obj is not original
+    assert copy_obj.nested is not original.nested
+
+
+def test_deepcopy_with_custom_deepcopy_fallback():
+    original = {"origin": NormalObject(10)}
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj is not original
+    assert copy_obj["origin"].value == original["origin"].value
+
+
+def test_shallow_copy_fallback():
+    original = {"origin": NonDeepcopyable(10)}
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj is not original
+    assert copy_obj["origin"].value == original["origin"].value
+
+
+def test_circular_reference():
+    original = []
+    original.append(original)
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj is not original
+    assert copy_obj[0] is copy_obj
+
+
+def test_memoization():
+    original = {"a": 1, "b": 2}
+    memo = {}
+    copy_obj = safe_deepcopy(original, memo)
+    assert copy_obj is memo[id(original)]
+
+
+def test_deepcopy_object_without_dict():
+    original = {"origin": WithoutDict(10)}
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj["origin"].value == original["origin"].value
+    assert copy_obj is not original
+    assert copy_obj["origin"] is original["origin"]
+    assert (
+        hasattr(copy_obj["origin"], "__dict__") is False
+    )  # Ensure __dict__ is not present
+
+    original = [WithoutDict(10)]
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj[0].value == original[0].value
+    assert copy_obj is not original
+    assert copy_obj[0] is original[0]
+
+    original = (WithoutDict(10),)
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj[0].value == original[0].value
+    assert copy_obj is not original
+    assert copy_obj[0] is original[0]
+
+    original_item = WithoutDict(10)
+    original = set([original_item])
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj is not original
+    copy_obj_item = copy_obj.pop()
+    assert copy_obj_item.value == original_item.value
+    assert copy_obj_item is original_item
+
+    original_item = WithoutDict(10)
+    original = frozenset([original_item])
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj is not original
+    copy_obj_item = list(copy_obj)[0]
+    assert copy_obj_item.value == original_item.value
+    assert copy_obj_item is original_item
+
+def test_memo():
+    obj = NormalObject(10)
+    original = {"origin": obj}
+    memo = {id(original):obj}
+    copy_obj = safe_deepcopy(original, memo)
+    assert copy_obj is memo[id(original)]
+
+def test_unhandled_type():
+    original = {"origin": NonCopyableObject(10)}
+    copy_obj = safe_deepcopy(original)
+    assert copy_obj["origin"].value == original["origin"].value
+    assert copy_obj is not original
+    assert copy_obj["origin"] is original["origin"]
+    assert hasattr(copy_obj, "__dict__") is False  # Ensure __dict__ is not present


### PR DESCRIPTION
link #609 
When copying the configuration with model_instance, an error may arise because model_instance is typically an uncopyable object. To fix it, I attempted to use safe_deepcopy to replace the internal deepcopy during the copying of the LLM configuration.

The safe_deepcopy function first attempts to use the internal deepcopy, ensuring it doesn't disrupt the original usage. If that fails, it resorts to alternative copying logic, such as shallow copying. In the worst-case scenario, it returns the original object.


## Note:
If there are any new graphs using deepcopy in future pull requests, special attention should be paid to copying the LLM configuration correctly.

## Other Considerations:
This pull request may not represent the best practice for resolving the issue, but it offers a quick fix. Here are some alternative approaches that I believe are superior:

* Using Pydantic Class Objects: Define the configuration with a Pydantic class object and implement a custom __deepcopy__ method. This approach requires significant refactoring but is more elegant.
* Replacing Internal Deepcopy: Utilize safe_deepcopy to replace the internal deepcopy. However, this might introduce unforeseen issues.
* Alternative Deepcopy Packages: Consider using other deepcopy packages, but I have yet to find a suitable option.

