### PR TITLE
Fix for #617 updated token calculation on parsenode

### DIFF
--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -132,6 +132,8 @@ class AbstractGraph(ABC):
                         "hugging_face", "deepseek", "ernie", "fireworks"}
 
         split_model_provider = llm_params["model"].split("/", 1)
+        if len(split_model_provider) < 2:
+            raise ValueError(f"Model must be specified in 'provider/modelname' format, but '{llm_params['model']}' was given")
         llm_params["model_provider"] = split_model_provider[0]
         llm_params["model"] = split_model_provider[1]
 

--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -141,7 +141,7 @@ class AbstractGraph(ABC):
         try:
             self.model_token = models_tokens[llm_params["model_provider"]][llm_params["model"]]
         except KeyError:
-            print("Model not found, using default token size (8192)")
+            print(f"Model {llm_params['model_provider']}/{llm_params['model']} not found, using default token size (8192)")
             self.model_token = 8192
 
         try:

--- a/scrapegraphai/graphs/deep_scraper_graph.py
+++ b/scrapegraphai/graphs/deep_scraper_graph.py
@@ -75,7 +75,8 @@ class DeepScraperGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
        

--- a/scrapegraphai/graphs/markdown_scraper_graph.py
+++ b/scrapegraphai/graphs/markdown_scraper_graph.py
@@ -60,7 +60,8 @@ class MDScraperGraph(AbstractGraph):
             output=["parsed_doc"],
             node_config={
                 "parse_html": False,
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
         generate_answer_node = GenerateAnswerNode(

--- a/scrapegraphai/graphs/omni_scraper_graph.py
+++ b/scrapegraphai/graphs/omni_scraper_graph.py
@@ -74,7 +74,8 @@ class OmniScraperGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
         image_to_text_node = ImageToTextNode(

--- a/scrapegraphai/graphs/pdf_scraper_graph.py
+++ b/scrapegraphai/graphs/pdf_scraper_graph.py
@@ -68,7 +68,8 @@ class PDFScraperGraph(AbstractGraph):
             output=["parsed_doc"],
             node_config={
                 "parse_html": False,
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
 

--- a/scrapegraphai/graphs/script_creator_graph.py
+++ b/scrapegraphai/graphs/script_creator_graph.py
@@ -73,7 +73,8 @@ class ScriptCreatorGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={"chunk_size": self.model_token,
-                         "parse_html": False
+                         "parse_html": False,
+                         "llm_model": self.llm_model
                          }
         )
         generate_scraper_node = GenerateScraperNode(

--- a/scrapegraphai/graphs/search_link_graph.py
+++ b/scrapegraphai/graphs/search_link_graph.py
@@ -64,7 +64,8 @@ class SearchLinkGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
         search_link_node = SearchLinkNode(

--- a/scrapegraphai/graphs/smart_scraper_graph.py
+++ b/scrapegraphai/graphs/smart_scraper_graph.py
@@ -74,7 +74,8 @@ class SmartScraperGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
 

--- a/scrapegraphai/graphs/speech_graph.py
+++ b/scrapegraphai/graphs/speech_graph.py
@@ -68,7 +68,8 @@ class SpeechGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
         generate_answer_node = GenerateAnswerNode(

--- a/scrapegraphai/nodes/parse_node.py
+++ b/scrapegraphai/nodes/parse_node.py
@@ -67,7 +67,7 @@ class ParseNode(BaseNode):
 
         def count_tokens(text):
             from ..utils import token_count
-            return token_count(text, self.llm_model.model_name)
+            return token_count(text, self.llm_model)
 
         if self.parse_html:
             docs_transformed = Html2TextTransformer().transform_documents(input_data[0])

--- a/scrapegraphai/utils/__init__.py
+++ b/scrapegraphai/utils/__init__.py
@@ -11,3 +11,4 @@ from .sys_dynamic_import import dynamic_import, srcfile_import
 from .cleanup_html import cleanup_html
 from .logging import *
 from .convert_to_md import convert_to_md
+from .token_calculator import *

--- a/scrapegraphai/utils/token_calculator.py
+++ b/scrapegraphai/utils/token_calculator.py
@@ -6,27 +6,26 @@ import tiktoken
 from ..helpers.models_tokens import models_tokens
 
 
-def truncate_text_tokens(text: str, model: str, encoding_name: str) -> List[str]:
+def truncate_text_tokens(text: str, model: str) -> List[str]:
     """
     Truncates text into chunks that are small enough to be processed by specified llm models.
 
     Args:
         text (str): The input text to be truncated.
         model (str): The name of the llm model to determine the maximum token limit.
-        encoding_name (str): The encoding strategy used to encode the text before truncation.
 
     Returns:
         List[str]: A list of text chunks, each within the token limit of the specified model.
 
     Example:
-        >>> truncate_text_tokens("This is a sample text for truncation.", "GPT-3", "EMBEDDING_ENCODING")
+        >>> truncate_text_tokens("This is a sample text for truncation.", "gpt-4o-mini")
         ["This is a sample text", "for truncation."]
 
     This function ensures that each chunk of text can be tokenized 
     by the specified model without exceeding the model's token limit.
     """
 
-    encoding = tiktoken.get_encoding(encoding_name)
+    encoding = tiktoken.encoding_for_model(model)
     max_tokens = min(models_tokens[model] - 500, int(models_tokens[model] * 0.9))
     encoded_text = encoding.encode(text)
 
@@ -36,3 +35,28 @@ def truncate_text_tokens(text: str, model: str, encoding_name: str) -> List[str]
     result = [encoding.decode(chunk) for chunk in chunks]
 
     return result
+
+
+def token_count(text: str, model: str) -> List[str]:
+    """
+    Return the number of tokens within the text, based on the encoding of the specified model.
+
+    Args:
+        text (str): The input text to be counted.
+        model (str): The name of the llm model to determine the encoding.
+
+    Returns:
+        int: Number of tokens.
+
+    Example:
+        >>> token_count("This is a sample text for counting.", "gpt-4o-mini")
+        9
+
+    This function ensures that each chunk of text can be tokenized 
+    by the specified model without exceeding the model's token limit.
+    """
+
+    encoding = tiktoken.encoding_for_model(model)
+    num_tokens = len(encoding.encode(text))
+
+    return num_tokens


### PR DESCRIPTION
This is a fix for #617 which changes the token counting from splitting the string on space characters to use `tiktoken`.

This is a precursor to fixing #543 .