### PR TITLE
543 script creator graph only use first chunk

### DIFF
--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -141,7 +141,7 @@ class AbstractGraph(ABC):
         try:
             self.model_token = models_tokens[llm_params["model_provider"]][llm_params["model"]]
         except KeyError:
-            print("Model not found, using default token size (8192)")
+            print(f"Model {llm_params['model_provider']}/{llm_params['model']} not found, using default token size (8192)")
             self.model_token = 8192
 
         try:

--- a/scrapegraphai/graphs/deep_scraper_graph.py
+++ b/scrapegraphai/graphs/deep_scraper_graph.py
@@ -75,7 +75,8 @@ class DeepScraperGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
        

--- a/scrapegraphai/graphs/markdown_scraper_graph.py
+++ b/scrapegraphai/graphs/markdown_scraper_graph.py
@@ -60,7 +60,8 @@ class MDScraperGraph(AbstractGraph):
             output=["parsed_doc"],
             node_config={
                 "parse_html": False,
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
         generate_answer_node = GenerateAnswerNode(

--- a/scrapegraphai/graphs/omni_scraper_graph.py
+++ b/scrapegraphai/graphs/omni_scraper_graph.py
@@ -74,7 +74,8 @@ class OmniScraperGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
         image_to_text_node = ImageToTextNode(

--- a/scrapegraphai/graphs/pdf_scraper_graph.py
+++ b/scrapegraphai/graphs/pdf_scraper_graph.py
@@ -68,7 +68,8 @@ class PDFScraperGraph(AbstractGraph):
             output=["parsed_doc"],
             node_config={
                 "parse_html": False,
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
 

--- a/scrapegraphai/graphs/script_creator_graph.py
+++ b/scrapegraphai/graphs/script_creator_graph.py
@@ -73,7 +73,8 @@ class ScriptCreatorGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={"chunk_size": self.model_token,
-                         "parse_html": False
+                         "parse_html": False,
+                         "llm_model": self.llm_model
                          }
         )
         generate_scraper_node = GenerateScraperNode(

--- a/scrapegraphai/graphs/script_creator_graph.py
+++ b/scrapegraphai/graphs/script_creator_graph.py
@@ -78,7 +78,7 @@ class ScriptCreatorGraph(AbstractGraph):
                          }
         )
         generate_scraper_node = GenerateScraperNode(
-            input="user_prompt & (doc)",
+            input="user_prompt & (parsed_doc)",
             output=["answer"],
             node_config={
                 "llm_model": self.llm_model,

--- a/scrapegraphai/graphs/search_link_graph.py
+++ b/scrapegraphai/graphs/search_link_graph.py
@@ -64,7 +64,8 @@ class SearchLinkGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
         search_link_node = SearchLinkNode(

--- a/scrapegraphai/graphs/speech_graph.py
+++ b/scrapegraphai/graphs/speech_graph.py
@@ -68,7 +68,8 @@ class SpeechGraph(AbstractGraph):
             input="doc",
             output=["parsed_doc"],
             node_config={
-                "chunk_size": self.model_token
+                "chunk_size": self.model_token,
+                "llm_model": self.llm_model
             }
         )
         generate_answer_node = GenerateAnswerNode(

--- a/scrapegraphai/nodes/generate_scraper_node.py
+++ b/scrapegraphai/nodes/generate_scraper_node.py
@@ -102,9 +102,19 @@ class GenerateScraperNode(BaseNode):
             TEMPLATE_NO_CHUNKS += self.additional_info
 
         if len(doc) > 1:
-            raise NotImplementedError(
-                "Currently GenerateScraperNode cannot handle more than 1 context chunks"
-            )
+            # Short term partial fix for issue #543 (Context length exceeded)
+            # If there are more than one chunks returned by ParseNode we just use the first one
+            # on the basis that the structure of the remainder of the HTML page is probably
+            # very similar to the first chunk therefore the generated script should still work.
+            # The better fix is to generate multiple scripts then use the LLM to merge them.
+
+            #raise NotImplementedError(
+            #    "Currently GenerateScraperNode cannot handle more than 1 context chunks"
+            #)
+            self.logger.warn(f"Warning: {self.node_name} Node provided with {len(doc)} chunks but can only "
+                "support 1, ignoring remaining chunks")
+            doc = [doc[0]]
+            template = TEMPLATE_NO_CHUNKS
         else:
             template = TEMPLATE_NO_CHUNKS
 

--- a/scrapegraphai/utils/__init__.py
+++ b/scrapegraphai/utils/__init__.py
@@ -11,3 +11,4 @@ from .sys_dynamic_import import dynamic_import, srcfile_import
 from .cleanup_html import cleanup_html
 from .logging import *
 from .convert_to_md import convert_to_md
+from .token_calculator import *

--- a/scrapegraphai/utils/token_calculator.py
+++ b/scrapegraphai/utils/token_calculator.py
@@ -6,27 +6,26 @@ import tiktoken
 from ..helpers.models_tokens import models_tokens
 
 
-def truncate_text_tokens(text: str, model: str, encoding_name: str) -> List[str]:
+def truncate_text_tokens(text: str, model: str) -> List[str]:
     """
     Truncates text into chunks that are small enough to be processed by specified llm models.
 
     Args:
         text (str): The input text to be truncated.
         model (str): The name of the llm model to determine the maximum token limit.
-        encoding_name (str): The encoding strategy used to encode the text before truncation.
 
     Returns:
         List[str]: A list of text chunks, each within the token limit of the specified model.
 
     Example:
-        >>> truncate_text_tokens("This is a sample text for truncation.", "GPT-3", "EMBEDDING_ENCODING")
+        >>> truncate_text_tokens("This is a sample text for truncation.", "gpt-4o-mini")
         ["This is a sample text", "for truncation."]
 
     This function ensures that each chunk of text can be tokenized 
     by the specified model without exceeding the model's token limit.
     """
 
-    encoding = tiktoken.get_encoding(encoding_name)
+    encoding = tiktoken.encoding_for_model(model)
     max_tokens = min(models_tokens[model] - 500, int(models_tokens[model] * 0.9))
     encoded_text = encoding.encode(text)
 
@@ -36,3 +35,28 @@ def truncate_text_tokens(text: str, model: str, encoding_name: str) -> List[str]
     result = [encoding.decode(chunk) for chunk in chunks]
 
     return result
+
+
+def token_count(text: str, model: str) -> List[str]:
+    """
+    Return the number of tokens within the text, based on the encoding of the specified model.
+
+    Args:
+        text (str): The input text to be counted.
+        model (str): The name of the llm model to determine the encoding.
+
+    Returns:
+        int: Number of tokens.
+
+    Example:
+        >>> token_count("This is a sample text for counting.", "gpt-4o-mini")
+        9
+
+    This function ensures that each chunk of text can be tokenized 
+    by the specified model without exceeding the model's token limit.
+    """
+
+    encoding = tiktoken.encoding_for_model(model)
+    num_tokens = len(encoding.encode(text))
+
+    return num_tokens


### PR DESCRIPTION
This is an initial fix for #543 when using ScriptCreatorGraph.  Because ParseNode provides multiple chunks when scraping long HTML pages, I have updated ScriptCreatorGraph to only use the first chunk, on the basis the structure of the remaining page is likely similar, therefore the generated script will work.

This seems to be working fine when using this scraper script:

```
from scrapegraphai.graphs import ScriptCreatorGraph

# Define the configuration for the scraping pipeline
graph_config = {
    "llm": {
        "api_key": "sk-proj-xxxxxx",
        "model": "openai/gpt-4o-mini",
    },
    "verbose": True,
    "headless": False,
    "library": "beautifulsoup"
}

url = 'https://old.reddit.com/r/gaming/comments/1exyrjv/ah_monkey_business/'
script_creator_graph = ScriptCreatorGraph(
    prompt="Get ALL comment that appear on this page, including the contents of the comment, the author, "
    "the score, and any child comments. Return as a hierarchical data structure.",
    source=url,
    config=graph_config
)

result = script_creator_graph.run()

 # Remove the first and last line
cleaned_content = result.strip().split('\n')[1:-1]

# Join the cleaned lines back into a string
cleaned_content = '\n'.join(cleaned_content)
print(cleaned_content)
with open('output.py', 'w') as file:
    file.write(cleaned_content)
```

The code above results in the following script being generated:

```
import requests
from bs4 import BeautifulSoup
import json

def main():
    url = "https://old.reddit.com/r/gaming/comments/1exyrjv/ah_monkey_business/"
    response = requests.get(url)
    soup = BeautifulSoup(response.text, 'html.parser')

    comments_data = []

    for comment in soup.find_all('div', class_='thing'):
        comment_info = {}
        author = comment.find('a', class_='author')
        score = comment.find('span', class_='score')
        content = comment.find('div', class_='usertext-body')
        
        if author and score and content:
            comment_info['author'] = author.text
            comment_info['score'] = int(score['title'])
            comment_info['content'] = content.get_text(strip=True)
            comment_info['children'] = []

            # Check for child comments
            child_comments = comment.find_all('div', class_='child')
            for child in child_comments:
                child_info = {}
                child_author = child.find('a', class_='author')
                child_score = child.find('span', class_='score')
                child_content = child.find('div', class_='usertext-body')

                if child_author and child_score and child_content:
                    child_info['author'] = child_author.text
                    child_info['score'] = int(child_score['title'])
                    child_info['content'] = child_content.get_text(strip=True)
                    comment_info['children'].append(child_info)

            comments_data.append(comment_info)

    print(json.dumps(comments_data, indent=4))

if __name__ == "__main__":
    main()
```

The generated script seems to work fine.  I think it's worth going with this solution for now, as I suspect it will work fine most of the time, and when I have a bit of spare time I will look at the idea of creating a script for each chunk and asking the LLM to merge the scripts.