### PR TITLE
problem

### DIFF
--- a/docs/chinese.md
+++ b/docs/chinese.md
@@ -133,7 +133,7 @@ from scrapegraphai.graphs import SpeechGraph
 graph_config = {
     "llm": {
         "api_key": "OPENAI_API_KEY",
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "tts_model": {
         "api_key": "OPENAI_API_KEY",

--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -133,7 +133,7 @@ from scrapegraphai.graphs import SpeechGraph
 graph_config = {
     "llm": {
         "api_key": "OPENAI_API_KEY",
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "tts_model": {
         "api_key": "OPENAI_API_KEY",

--- a/docs/korean.md
+++ b/docs/korean.md
@@ -132,7 +132,7 @@ from scrapegraphai.graphs import SpeechGraph
 graph_config = {
     "llm": {
         "api_key": "OPENAI_API_KEY",
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "tts_model": {
         "api_key": "OPENAI_API_KEY",

--- a/docs/russian.md
+++ b/docs/russian.md
@@ -138,7 +138,7 @@ from scrapegraphai.graphs import SpeechGraph
 graph_config = {
     "llm": {
         "api_key": "OPENAI_API_KEY",
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "tts_model": {
         "api_key": "OPENAI_API_KEY",

--- a/docs/source/getting_started/examples.rst
+++ b/docs/source/getting_started/examples.rst
@@ -22,7 +22,7 @@ OpenAI models
    graph_config = {
       "llm": {
          "api_key": openai_key,
-         "model": "gpt-3.5-turbo",
+         "model": "openai/gpt-3.5-turbo",
       },
    }
 

--- a/examples/benchmarks/GenerateScraper/benchmark_openai_gpt35.py
+++ b/examples/benchmarks/GenerateScraper/benchmark_openai_gpt35.py
@@ -24,7 +24,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "library": "beautifoulsoup"
 }

--- a/examples/benchmarks/GenerateScraper/benchmark_openai_gpt4.py
+++ b/examples/benchmarks/GenerateScraper/benchmark_openai_gpt4.py
@@ -24,7 +24,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-4-turbo-2024-04-09",
+        "model": "openai/gpt-4-turbo-2024-04-09",
     },
     "library": "beautifoulsoup"
 }

--- a/examples/benchmarks/SmartScraper/benchmark_openai_gpt35.py
+++ b/examples/benchmarks/SmartScraper/benchmark_openai_gpt35.py
@@ -24,7 +24,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
 }
 

--- a/examples/benchmarks/SmartScraper/benchmark_openai_gpt4.py
+++ b/examples/benchmarks/SmartScraper/benchmark_openai_gpt4.py
@@ -25,7 +25,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-4-turbo",
+        "model": "openai/gpt-4-turbo",
     },
 }
 

--- a/examples/benchmarks/SmartScraper/benchmark_openai_gpt4o.py
+++ b/examples/benchmarks/SmartScraper/benchmark_openai_gpt4o.py
@@ -25,7 +25,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-4o",
+        "model": "openai/gpt-4o",
     },
 }
 

--- a/examples/extras/custom_prompt.py
+++ b/examples/extras/custom_prompt.py
@@ -21,7 +21,7 @@ prompt = "Some more info"
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "additional_info": prompt,
     "verbose": True,

--- a/examples/extras/no_cut.py
+++ b/examples/extras/no_cut.py
@@ -15,7 +15,7 @@ from scrapegraphai.utils import prettify_exec_info
 graph_config = {
     "llm": {
         "api_key": "s",
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "cut": False,
     "verbose": True,

--- a/examples/extras/proxy_rotation.py
+++ b/examples/extras/proxy_rotation.py
@@ -13,7 +13,7 @@ from scrapegraphai.utils import prettify_exec_info
 graph_config = {
     "llm": {
         "api_key": "API_KEY",
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "loader_kwargs": {
         "proxy" : {

--- a/examples/extras/rag_caching.py
+++ b/examples/extras/rag_caching.py
@@ -19,7 +19,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "caching": True
 }

--- a/examples/extras/serch_graph_scehma.py
+++ b/examples/extras/serch_graph_scehma.py
@@ -23,7 +23,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-4o",
+        "model": "openai/gpt-4o",
         },
     "max_results": 2,
     "verbose": True,

--- a/examples/integrations/indexify_node_example.py
+++ b/examples/integrations/indexify_node_example.py
@@ -32,7 +32,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key":openai_key,
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "verbose": True,
     "headless": False,

--- a/examples/oneapi/pdf_scraper_multi_oneapi.py
+++ b/examples/oneapi/pdf_scraper_multi_oneapi.py
@@ -13,7 +13,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
 }
 

--- a/examples/oneapi/xml_scraper_graph_multi_oneapi.py
+++ b/examples/oneapi/xml_scraper_graph_multi_oneapi.py
@@ -28,7 +28,7 @@ openai_key = os.getenv("OPENAI_APIKEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
 }
 

--- a/examples/oneapi/xml_scraper_oneapi.py
+++ b/examples/oneapi/xml_scraper_oneapi.py
@@ -28,7 +28,7 @@ openai_key = os.getenv("ONEAPI_KEY")
 graph_config = {
     "llm": {
         "api_key": openai_key,
-        "model": "gpt-3.5-turbo",
+        "model": "openai/gpt-3.5-turbo",
     },
     "verbose":False,
 }

--- a/examples/openai/script_generator_openai.py
+++ b/examples/openai/script_generator_openai.py
@@ -18,7 +18,7 @@ load_dotenv()
 graph_config = {
     "llm": {
         "api_key": os.getenv("OPENAI_API_KEY"),
-        "model": "gpt-4o",
+        "model": "openai/gpt-4o",
     },
     "verbose": True,
     "headless": False,

--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -40,7 +40,7 @@ class AbstractGraph(ABC):
         ...         return graph
         ...
         >>> my_graph = MyGraph("Example Graph", 
-        {"llm": {"model": "gpt-3.5-turbo"}}, "example_source")
+        {"llm": {"model": "openai/gpt-3.5-turbo"}}, "example_source")
         >>> result = my_graph.run()
     """
 

--- a/scrapegraphai/graphs/csv_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/csv_scraper_multi_graph.py
@@ -36,7 +36,7 @@ class CSVScraperMultiGraph(AbstractGraph):
     Example:
         >>> search_graph = MultipleSearchGraph(
         ...     "What is Chioggia famous for?",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = search_graph.run()
     """

--- a/scrapegraphai/graphs/deep_scraper_graph.py
+++ b/scrapegraphai/graphs/deep_scraper_graph.py
@@ -46,7 +46,7 @@ class DeepScraperGraph(AbstractGraph):
         >>> deep_scraper = DeepScraperGraph(
         ...     "List me all the job titles and detailed job description.",
         ...     "https://www.google.com/about/careers/applications/jobs/results/?location=Bangalore%20India",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = deep_scraper.run()
         )

--- a/scrapegraphai/graphs/json_scraper_graph.py
+++ b/scrapegraphai/graphs/json_scraper_graph.py
@@ -35,7 +35,7 @@ class JSONScraperGraph(AbstractGraph):
         >>> json_scraper = JSONScraperGraph(
         ...     "List me all the attractions in Chioggia.",
         ...     "data/chioggia.json",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = json_scraper.run()
     """

--- a/scrapegraphai/graphs/json_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/json_scraper_multi_graph.py
@@ -37,7 +37,7 @@ class JSONScraperMultiGraph(AbstractGraph):
     Example:
         >>> search_graph = MultipleSearchGraph(
         ...     "What is Chioggia famous for?",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = search_graph.run()
     """

--- a/scrapegraphai/graphs/markdown_scraper_graph.py
+++ b/scrapegraphai/graphs/markdown_scraper_graph.py
@@ -35,7 +35,7 @@ class MDScraperGraph(AbstractGraph):
         >>> smart_scraper = MDScraperGraph(
         ...     "List me all the attractions in Chioggia.",
         ...     "https://en.wikipedia.org/wiki/Chioggia",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = smart_scraper.run()
     """

--- a/scrapegraphai/graphs/markdown_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/markdown_scraper_multi_graph.py
@@ -36,7 +36,7 @@ class MDScraperMultiGraph(AbstractGraph):
         >>> search_graph = MDScraperMultiGraph(
         ...     "What is Chioggia famous for?",
         ...     ["http://example.com/page1", "http://example.com/page2"],
-        ...     {"llm_model": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm_model": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = search_graph.run()
     """

--- a/scrapegraphai/graphs/omni_scraper_graph.py
+++ b/scrapegraphai/graphs/omni_scraper_graph.py
@@ -42,7 +42,7 @@ class OmniScraperGraph(AbstractGraph):
         >>> omni_scraper = OmniScraperGraph(
         ...     "List me all the attractions in Chioggia and describe their pictures.",
         ...     "https://en.wikipedia.org/wiki/Chioggia",
-        ...     {"llm": {"model": "gpt-4o"}}
+        ...     {"llm": {"model": "openai/gpt-4o"}}
         ... )
         >>> result = omni_scraper.run()
         )

--- a/scrapegraphai/graphs/omni_search_graph.py
+++ b/scrapegraphai/graphs/omni_search_graph.py
@@ -38,7 +38,7 @@ class OmniSearchGraph(AbstractGraph):
     Example:
         >>> omni_search_graph = OmniSearchGraph(
         ...     "What is Chioggia famous for?",
-        ...     {"llm": {"model": "gpt-4o"}}
+        ...     {"llm": {"model": "openai/gpt-4o"}}
         ... )
         >>> result = search_graph.run()
     """

--- a/scrapegraphai/graphs/pdf_scraper_graph.py
+++ b/scrapegraphai/graphs/pdf_scraper_graph.py
@@ -39,7 +39,7 @@ class PDFScraperGraph(AbstractGraph):
         >>> pdf_scraper = PDFScraperGraph(
         ...     "List me all the attractions in Chioggia.",
         ...     "data/chioggia.pdf",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = pdf_scraper.run()
     """

--- a/scrapegraphai/graphs/pdf_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/pdf_scraper_multi_graph.py
@@ -37,7 +37,7 @@ class PdfScraperMultiGraph(AbstractGraph):
     Example:
         >>> search_graph = MultipleSearchGraph(
         ...     "What is Chioggia famous for?",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = search_graph.run()
     """

--- a/scrapegraphai/graphs/script_creator_graph.py
+++ b/scrapegraphai/graphs/script_creator_graph.py
@@ -38,7 +38,7 @@ class ScriptCreatorGraph(AbstractGraph):
         >>> script_creator = ScriptCreatorGraph(
         ...     "List me all the attractions in Chioggia.",
         ...     "https://en.wikipedia.org/wiki/Chioggia",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = script_creator.run()
     """

--- a/scrapegraphai/graphs/script_creator_multi_graph.py
+++ b/scrapegraphai/graphs/script_creator_multi_graph.py
@@ -34,7 +34,7 @@ class ScriptCreatorMultiGraph(AbstractGraph):
         >>> script_graph = ScriptCreatorMultiGraph(
         ...     "What is Chioggia famous for?",
         ...     source=[],
-        ...     config={"llm": {"model": "gpt-3.5-turbo"}}
+        ...     config={"llm": {"model": "openai/gpt-3.5-turbo"}}
         ...     schema={}
         ... )
         >>> result = script_graph.run()

--- a/scrapegraphai/graphs/search_graph.py
+++ b/scrapegraphai/graphs/search_graph.py
@@ -39,7 +39,7 @@ class SearchGraph(AbstractGraph):
     Example:
         >>> search_graph = SearchGraph(
         ...     "What is Chioggia famous for?",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = search_graph.run()
         >>> print(search_graph.get_considered_urls())

--- a/scrapegraphai/graphs/search_link_graph.py
+++ b/scrapegraphai/graphs/search_link_graph.py
@@ -34,7 +34,7 @@ class SearchLinkGraph(AbstractGraph):
         >>> smart_scraper = SearchLinkGraph(
         ...     "List me all the attractions in Chioggia.",
         ...     "https://en.wikipedia.org/wiki/Chioggia",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = smart_scraper.run()
     """

--- a/scrapegraphai/graphs/smart_scraper_graph.py
+++ b/scrapegraphai/graphs/smart_scraper_graph.py
@@ -39,7 +39,7 @@ class SmartScraperGraph(AbstractGraph):
         >>> smart_scraper = SmartScraperGraph(
         ...     "List me all the attractions in Chioggia.",
         ...     "https://en.wikipedia.org/wiki/Chioggia",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = smart_scraper.run()
         )

--- a/scrapegraphai/graphs/smart_scraper_multi_concat_graph.py
+++ b/scrapegraphai/graphs/smart_scraper_multi_concat_graph.py
@@ -39,7 +39,7 @@ class SmartScraperMultiConcatGraph(AbstractGraph):
     Example:
         >>> search_graph = SmartScraperMultiConcatGraph(
         ...     "What is Chioggia famous for?",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = search_graph.run()
     """

--- a/scrapegraphai/graphs/smart_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/smart_scraper_multi_graph.py
@@ -37,7 +37,7 @@ class SmartScraperMultiGraph(AbstractGraph):
     Example:
         >>> search_graph = MultipleSearchGraph(
         ...     "What is Chioggia famous for?",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = search_graph.run()
     """

--- a/scrapegraphai/graphs/speech_graph.py
+++ b/scrapegraphai/graphs/speech_graph.py
@@ -41,7 +41,7 @@ class SpeechGraph(AbstractGraph):
         >>> speech_graph = SpeechGraph(
         ...     "List me all the attractions in Chioggia and generate an audio summary.",
         ...     "https://en.wikipedia.org/wiki/Chioggia",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
     """
 
     def __init__(self, prompt: str, source: str, config: dict, schema: Optional[BaseModel] = None):

--- a/scrapegraphai/graphs/xml_scraper_graph.py
+++ b/scrapegraphai/graphs/xml_scraper_graph.py
@@ -38,7 +38,7 @@ class XMLScraperGraph(AbstractGraph):
         >>> xml_scraper = XMLScraperGraph(
         ...     "List me all the attractions in Chioggia.",
         ...     "data/chioggia.xml",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = xml_scraper.run()
     """

--- a/scrapegraphai/graphs/xml_scraper_multi_graph.py
+++ b/scrapegraphai/graphs/xml_scraper_multi_graph.py
@@ -37,7 +37,7 @@ class XMLScraperMultiGraph(AbstractGraph):
     Example:
         >>> search_graph = MultipleSearchGraph(
         ...     "What is Chioggia famous for?",
-        ...     {"llm": {"model": "gpt-3.5-turbo"}}
+        ...     {"llm": {"model": "openai/gpt-3.5-turbo"}}
         ... )
         >>> result = search_graph.run()
     """


### PR DESCRIPTION
In the documentation and example, some graph_config model values are missing the provider information. Here's the original config example:
```
graph_config = {
    "llm": {
        "api_key": openai_key,
        "model": "gpt-4o",
    },
}
```
update to:
```
graph_config = {
    "llm": {
        "api_key": openai_key,
        "model": "openai/gpt-4o",
    },
}
```
I’ve updated the docs where the model value lacks the provider prefix.