### PR TITLE
fix: Add mistral-common dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "langchain-mistralai>=0.1.12",
     "langchain_community>=0.2.9",
     "langchain-aws>=0.1.3",
+    "mistral-common>=1.4.0"
     "html2text>=2024.2.26",
     "faiss-cpu>=1.8.0",
     "beautifulsoup4>=4.12.3",


### PR DESCRIPTION
mistral-common dependency is necessary for tokeniser utilities while using MistralAI.
https://github.com/ScrapeGraphAI/Scrapegraph-ai/blob/pre/beta/scrapegraphai/utils/tokenizers/tokenizer_mistral.py