### PR TITLE
Clean up cache files to reduce Docker image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.11-slim
 
-RUN apt-get update && apt-get upgrade -y
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
 
-RUN pip install scrapegraphai
-RUN pip install scrapegraphai[burr]
+RUN pip install --no-cache-dir scrapegraphai
+RUN pip install --no-cache-dir scrapegraphai[burr]
 
 RUN python3 -m playwright install-deps
 RUN python3 -m playwright install


### PR DESCRIPTION
Remove unnecessary cache files and temporary data:
- Remove apt lists after package installation
- Use pip --no-cache-dir flag

Image size comparison:

```
REPOSITORY         TAG      IMAGE ID       CREATED          SIZE
scrapegraph-ai     after    609a2ecf4678   20 minutes ago   3.1GB
scrapegraph-ai     before   e3093b782ab0   24 minutes ago   3.39GB
```

This reduced about 0.29GB image size by preventing cache files from being included in the final image layers.