### PR TITLE
fix: validate URL only if the input type is a URL

### DIFF
--- a/scrapegraphai/nodes/fetch_node.py
+++ b/scrapegraphai/nodes/fetch_node.py
@@ -131,12 +131,13 @@ class FetchNode(BaseNode):
             return state
 
         # For web sources, validate URL before proceeding
-        try:
-            if self.is_valid_url(source):
-                return self.handle_web_source(state, source)
-        except ValueError as e:
-            # Re-raise the exception from is_valid_url
-            raise
+        if input_type == "url":
+            try:
+                if self.is_valid_url(source):
+                    return self.handle_web_source(state, source)
+            except ValueError as e:
+                # Re-raise the exception from is_valid_url
+                raise
 
         return self.handle_local_source(state, source)
 


### PR DESCRIPTION
If you pass a string with the downloaded html as input, the scraper will fail because it will check if the input is a valid url.

The solution below checks whether the input type is a url _before_ trying to validate the url itself. This now works both for url and html input types.

The issue was first reported in #735 but it's falsely closed. 