### PR TITLE
Update llm.rst

### DIFF
--- a/docs/source/scrapers/llm.rst
+++ b/docs/source/scrapers/llm.rst
@@ -30,7 +30,7 @@ Then we can use them in the graph configuration as follows:
 
     graph_config = {
         "llm": {
-            "model": "llama3",
+            "model": "ollama/llama3",
             "temperature": 0.0,
             "format": "json",
         },


### PR DESCRIPTION
In latest version, if you don't add the model provider separated by a slash in front of the model name, this will return error. 

```
 File ".venv/lib/python3.11/site-packages/scrapegraphai/graphs/abstract_graph.py", line 180, in _create_llm
    f"""Provider {llm_params['model_provider']} is not supported.
                  ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
KeyError: 'model_provider'
```

I tested adding "ollama/" in front of model name and it works. I assume this should be fixed for other providers too, but I haven't tested that personally.