### PR TITLE
docs: add links to other language versions of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 [English](https://github.com/VinciGit00/Scrapegraph-ai/blob/main/README.md) | [中文](https://github.com/VinciGit00/Scrapegraph-ai/blob/main/docs/chinese.md) | [日本語](https://github.com/VinciGit00/Scrapegraph-ai/blob/main/docs/japanese.md)
 | [한국어](https://github.com/VinciGit00/Scrapegraph-ai/blob/main/docs/korean.md)
 | [Русский](https://github.com/VinciGit00/Scrapegraph-ai/blob/main/docs/russian.md) | [Türkçe](https://github.com/VinciGit00/Scrapegraph-ai/blob/main/docs/turkish.md)
+| [Deutsch](https://www.readme-i18n.com/ScrapeGraphAI/Scrapegraph-ai?lang=de) 
+| [Español](https://www.readme-i18n.com/ScrapeGraphAI/Scrapegraph-ai?lang=es)
+| [français](https://www.readme-i18n.com/ScrapeGraphAI/Scrapegraph-ai?lang=fr)
+| [Português](https://www.readme-i18n.com/ScrapeGraphAI/Scrapegraph-ai?lang=pt)
 
 
 [![Downloads](https://img.shields.io/pepy/dt/scrapegraphai?style=for-the-badge)](https://pepy.tech/project/scrapegraphai)


### PR DESCRIPTION
Added language selection links to the README for easier access to translated versions: German, Spanish, French, and Portuguese.

These links point to dynamically updated translations of the README. Whenever the original README is modified, the translated versions are automatically synchronized.

Additional commonly used languages are also available and can be optionally included:
```md
[日本語](https://www.readme-i18n.com/ScrapeGraphAI/Scrapegraph-ai?lang=ja) | 
[한국어](https://www.readme-i18n.com/ScrapeGraphAI/Scrapegraph-ai?lang=ko) | 
[Русский](https://www.readme-i18n.com/ScrapeGraphAI/Scrapegraph-ai?lang=ru) | 
[中文](https://www.readme-i18n.com/ScrapeGraphAI/Scrapegraph-ai?lang=zh)
```

The updated links can be previewed in my forked repository: https://github.com/dowithless/Scrapegraph-ai/tree/patch-1
