### PR TITLE
fix: add null check for document.body when reading scrollHeight

### DIFF
--- a/scrapegraphai/docloaders/chromium.py
+++ b/scrapegraphai/docloaders/chromium.py
@@ -265,7 +265,7 @@ class ChromiumLoader(BaseLoader):
 
                     while True:
                         current_height = await page.evaluate(
-                            "document.body.scrollHeight"
+                            "document.body ? document.body.scrollHeight : document.documentElement.scrollHeight"
                         )
                         heights.append(current_height)
                         heights = heights[


### PR DESCRIPTION
On some pages document.body can be null (non-standard DOM structure or early script execution). Accessing document.body.scrollHeight caused errors in these cases.