### PR TITLE
Add format key to LLM configuration, solve bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,8 @@ from scrapegraphai.graphs import SmartScraperGraph
 graph_config = {
     "llm": {
         "model": "ollama/llama3.2",
-        "model_tokens": 8192
+        "model_tokens": 8192,
+        "format": "json",
     },
     "verbose": True,
     "headless": False,


### PR DESCRIPTION
## Problem
The current README example fails with a `JSONDecodeError` when using Ollama with llama3.2. The LLM returns plain text instead of JSON, causing the parser to fail.

### Error Details
```
OutputParserException:  Invalid json output: This text is a web page... 
```

**Environment:**
- scrapegraphai v1.71.0
- langchain-ollama v1.0.1
- langchain v1.2.1

## Solution
Add `"format": "json"` to the Ollama configuration to force JSON output format. 

```python
graph_config = {
    "llm": {
        "model":   "ollama/llama3.2",
        "model_tokens": 8192,
        "format": "json",  # ← This ensures structured JSON output
    },
}
```

## Testing
✅ Tested on M4 MacBook with llama3.2  
✅ Example now runs successfully without JSON parsing errors

## Additional Notes
The `format` parameter is a standard Ollama API option that ensures the model returns valid JSON, which is required by ScrapeGraphAI's output parser. 

⚠️ Execution time:  Further optimizations possible (from 1m26s to ~16s with additional configuration changes)