### PR TITLE
feat: add OpenAI Batch API support for SmartScraperMultiGraph

### DIFF
--- a/scrapegraphai/graphs/__init__.py
+++ b/scrapegraphai/graphs/__init__.py
@@ -23,6 +23,7 @@ from .smart_scraper_graph import SmartScraperGraph
 from .smart_scraper_lite_graph import SmartScraperLiteGraph
 from .smart_scraper_multi_concat_graph import SmartScraperMultiConcatGraph
 from .smart_scraper_multi_graph import SmartScraperMultiGraph
+from .smart_scraper_multi_batch_graph import SmartScraperMultiBatchGraph
 from .smart_scraper_multi_lite_graph import SmartScraperMultiLiteGraph
 from .speech_graph import SpeechGraph
 from .xml_scraper_graph import XMLScraperGraph
@@ -45,6 +46,7 @@ __all__ = [
     "SmartScraperGraph",
     "SmartScraperLiteGraph",
     "SmartScraperMultiGraph",
+    "SmartScraperMultiBatchGraph",
     "SmartScraperMultiLiteGraph",
     "SmartScraperMultiConcatGraph",
     # Search-related graphs

--- a/scrapegraphai/graphs/smart_scraper_multi_batch_graph.py
+++ b/scrapegraphai/graphs/smart_scraper_multi_batch_graph.py
@@ -1,0 +1,216 @@
+"""
+SmartScraperMultiBatchGraph Module
+
+A scraping pipeline that uses the OpenAI Batch API for LLM calls,
+providing 50% cost savings compared to real-time API calls.
+"""
+
+import asyncio
+from copy import deepcopy
+from typing import Dict, List, Optional, Type
+
+from pydantic import BaseModel
+
+from ..nodes import FetchNode, GraphIteratorNode, ParseNode
+from ..nodes.batch_generate_answer_node import BatchGenerateAnswerNode
+from ..nodes.merge_answers_node import MergeAnswersNode
+from ..utils.copy import safe_deepcopy
+from .abstract_graph import AbstractGraph
+from .base_graph import BaseGraph
+from .smart_scraper_graph import SmartScraperGraph
+
+
+class _FetchParseOnlyGraph(AbstractGraph):
+    """Internal graph that only fetches and parses a URL (no LLM generation).
+
+    This is used to separate the fetch/parse phase from the LLM generation
+    phase, allowing all LLM calls to be batched together.
+    """
+
+    def __init__(
+        self,
+        prompt: str,
+        source: str,
+        config: dict,
+        schema: Optional[Type[BaseModel]] = None,
+    ):
+        super().__init__(prompt, config, source, schema)
+        self.input_key = "url" if source.startswith("http") else "local_dir"
+
+    def _create_graph(self) -> BaseGraph:
+        fetch_node = FetchNode(
+            input="url | local_dir",
+            output=["doc"],
+            node_config={
+                "llm_model": self.llm_model,
+                "force": self.config.get("force", False),
+                "cut": self.config.get("cut", True),
+                "loader_kwargs": self.config.get("loader_kwargs", {}),
+                "browser_base": self.config.get("browser_base"),
+                "scrape_do": self.config.get("scrape_do"),
+                "storage_state": self.config.get("storage_state"),
+            },
+        )
+        parse_node = ParseNode(
+            input="doc",
+            output=["parsed_doc"],
+            node_config={
+                "llm_model": self.llm_model,
+                "chunk_size": self.model_token,
+            },
+        )
+
+        return BaseGraph(
+            nodes=[fetch_node, parse_node],
+            edges=[(fetch_node, parse_node)],
+            entry_point=fetch_node,
+            graph_name=self.__class__.__name__,
+        )
+
+    def run(self) -> str:
+        inputs = {"user_prompt": self.prompt, self.input_key: self.source}
+        self.final_state, self.execution_info = self.graph.execute(inputs)
+        return self.final_state.get("parsed_doc", "")
+
+
+class SmartScraperMultiBatchGraph(AbstractGraph):
+    """A scraping pipeline that uses OpenAI Batch API for cost savings.
+
+    Similar to SmartScraperMultiGraph, but instead of making individual
+    LLM calls per URL, it:
+    1. Fetches and parses all URLs concurrently (Phase 1)
+    2. Collects all prompts and submits them as a single OpenAI Batch (Phase 2)
+    3. Polls for batch completion (Phase 3)
+    4. Merges all results into a final answer (Phase 4)
+
+    This provides ~50% cost savings on OpenAI API calls at the expense
+    of higher latency (up to 24 hours for batch completion).
+
+    Attributes:
+        prompt (str): The user prompt for scraping.
+        source (List[str]): List of URLs to scrape.
+        config (dict): Configuration including 'llm' and optional 'batch_api' settings.
+        schema (Optional[BaseModel]): Optional Pydantic schema for structured output.
+
+    Config options under 'batch_api':
+        poll_interval (int): Seconds between batch status checks (default: 30).
+        max_wait_time (int): Maximum wait time in seconds (default: 86400 = 24h).
+        model (str): Override model for batch requests (optional).
+        temperature (float): Temperature for batch requests (default: 0.0).
+
+    Example:
+        >>> graph = SmartScraperMultiBatchGraph(
+        ...     prompt="Extract the main topic and key points",
+        ...     source=[
+        ...         "https://example.com/page1",
+        ...         "https://example.com/page2",
+        ...     ],
+        ...     config={
+        ...         "llm": {"model": "openai/gpt-4o-mini"},
+        ...         "batch_api": {
+        ...             "poll_interval": 30,
+        ...             "max_wait_time": 3600,
+        ...         },
+        ...     }
+        ... )
+        >>> result = graph.run()
+    """
+
+    def __init__(
+        self,
+        prompt: str,
+        source: List[str],
+        config: dict,
+        schema: Optional[Type[BaseModel]] = None,
+    ):
+        self.copy_config = safe_deepcopy(config)
+        self.copy_schema = deepcopy(schema)
+        self.batch_config = config.get("batch_api", {})
+
+        # Validate that the model is OpenAI-based
+        model_str = config.get("llm", {}).get("model", "")
+        if "/" in model_str:
+            provider = model_str.split("/")[0]
+        else:
+            provider = ""
+        if provider and provider != "openai":
+            raise ValueError(
+                f"SmartScraperMultiBatchGraph only supports OpenAI models. "
+                f"Got provider '{provider}'. "
+                f"Use SmartScraperMultiGraph for other providers."
+            )
+
+        super().__init__(prompt, config, source, schema)
+
+    def _create_graph(self) -> BaseGraph:
+        """Creates the graph of nodes for the batch scraping pipeline.
+
+        The graph has two phases:
+        1. GraphIteratorNode runs _FetchParseOnlyGraph per URL (concurrent)
+        2. BatchGenerateAnswerNode submits all prompts via Batch API
+        3. MergeAnswersNode combines the results
+
+        Returns:
+            BaseGraph: A graph instance representing the batch scraping workflow.
+        """
+        # Phase 1: Fetch and parse all URLs concurrently
+        graph_iterator_node = GraphIteratorNode(
+            input="user_prompt & urls",
+            output=["parsed_docs"],
+            node_config={
+                "graph_instance": _FetchParseOnlyGraph,
+                "scraper_config": self.copy_config,
+            },
+            schema=self.copy_schema,
+        )
+
+        # Phase 2: Submit all prompts to OpenAI Batch API
+        batch_generate_node = BatchGenerateAnswerNode(
+            input="user_prompt & parsed_docs",
+            output=["results"],
+            node_config={
+                "llm_model": self.llm_model,
+                "schema": self.copy_schema,
+                "batch_config": self.batch_config,
+            },
+        )
+
+        # Phase 3: Merge all results
+        merge_answers_node = MergeAnswersNode(
+            input="user_prompt & results",
+            output=["answer"],
+            node_config={
+                "llm_model": self.llm_model,
+                "schema": self.copy_schema,
+            },
+        )
+
+        return BaseGraph(
+            nodes=[
+                graph_iterator_node,
+                batch_generate_node,
+                merge_answers_node,
+            ],
+            edges=[
+                (graph_iterator_node, batch_generate_node),
+                (batch_generate_node, merge_answers_node),
+            ],
+            entry_point=graph_iterator_node,
+            graph_name=self.__class__.__name__,
+        )
+
+    def run(self) -> str:
+        """Executes the full batch scraping pipeline.
+
+        This will:
+        1. Fetch and parse all URLs concurrently
+        2. Submit all LLM prompts as an OpenAI Batch
+        3. Poll until the batch completes (may take minutes to hours)
+        4. Merge results into a final answer
+
+        Returns:
+            str: The merged answer from all scraped URLs.
+        """
+        inputs = {"user_prompt": self.prompt, "urls": self.source}
+        self.final_state, self.execution_info = self.graph.execute(inputs)
+        return self.final_state.get("answer", "No answer found.")

--- a/scrapegraphai/nodes/__init__.py
+++ b/scrapegraphai/nodes/__init__.py
@@ -3,6 +3,7 @@ __init__.py file for node folder module
 """
 
 from .base_node import BaseNode
+from .batch_generate_answer_node import BatchGenerateAnswerNode
 from .concat_answers_node import ConcatAnswersNode
 from .conditional_node import ConditionalNode
 from .description_node import DescriptionNode
@@ -53,6 +54,7 @@ __all__ = [
     "DescriptionNode",
     "ReasoningNode",
     # Generation nodes
+    "BatchGenerateAnswerNode",
     "GenerateAnswerNode",
     "GenerateAnswerNodeKLevel",
     "GenerateAnswerCSVNode",

--- a/scrapegraphai/nodes/batch_generate_answer_node.py
+++ b/scrapegraphai/nodes/batch_generate_answer_node.py
@@ -1,0 +1,253 @@
+"""
+BatchGenerateAnswerNode Module
+
+A node that collects LLM prompts from multiple scraped documents
+and submits them as a single OpenAI Batch API request for 50% cost savings.
+"""
+
+import json
+import logging
+from typing import Any, Dict, List, Optional
+
+from langchain.prompts import PromptTemplate
+from langchain_core.output_parsers import JsonOutputParser
+
+from ..prompts import (
+    TEMPLATE_NO_CHUNKS_MD,
+    TEMPLATE_NO_CHUNKS,
+)
+from ..utils.batch_api import (
+    BatchRequest,
+    BatchResult,
+    create_batch,
+    poll_batch_until_complete,
+    retrieve_batch_results,
+)
+from ..utils.output_parser import get_pydantic_output_parser
+from .base_node import BaseNode
+
+logger = logging.getLogger(__name__)
+
+
+class BatchGenerateAnswerNode(BaseNode):
+    """A node that generates answers using the OpenAI Batch API.
+
+    Instead of making individual LLM calls for each document,
+    this node collects all prompts and submits them as a single
+    batch request for 50% cost savings.
+
+    Attributes:
+        llm_model: The language model configuration (must be OpenAI).
+        verbose (bool): Whether to show progress information.
+
+    Args:
+        input (str): Boolean expression defining the input keys needed.
+        output (List[str]): List of output keys to be updated in the state.
+        node_config (Optional[dict]): Configuration dictionary containing:
+            - llm_model: The LLM model configuration.
+            - schema: Optional Pydantic schema for structured output.
+            - additional_info: Optional additional prompt context.
+            - batch_config: Optional dict with batch-specific settings:
+                - poll_interval: Seconds between status checks (default: 30).
+                - max_wait_time: Maximum wait in seconds (default: 86400).
+                - model: Override model for batch (optional).
+                - temperature: Override temperature (default: 0.0).
+        node_name (str): The unique identifier for this node.
+    """
+
+    def __init__(
+        self,
+        input: str,
+        output: List[str],
+        node_config: Optional[dict] = None,
+        node_name: str = "BatchGenerateAnswer",
+    ):
+        super().__init__(node_name, "node", input, output, 2, node_config)
+
+        self.llm_model = node_config["llm_model"]
+        self.verbose = node_config.get("verbose", False)
+        self.additional_info = node_config.get("additional_info")
+        self.is_md_scraper = node_config.get("is_md_scraper", True)
+        self.schema = node_config.get("schema")
+
+        # Batch-specific configuration
+        batch_config = node_config.get("batch_config", {})
+        self.poll_interval = batch_config.get("poll_interval", 30)
+        self.max_wait_time = batch_config.get("max_wait_time", 86_400)
+        self.batch_model = batch_config.get("model")
+        self.batch_temperature = batch_config.get("temperature", 0.0)
+
+    def _get_model_name(self) -> str:
+        """Extract the OpenAI model name from the LLM configuration.
+
+        Returns:
+            The model name string (e.g., 'gpt-4o-mini').
+        """
+        if self.batch_model:
+            return self.batch_model
+
+        # Try to extract model name from the LangChain model instance
+        if hasattr(self.llm_model, "model_name"):
+            return self.llm_model.model_name
+        if hasattr(self.llm_model, "model"):
+            return self.llm_model.model
+
+        raise ValueError(
+            "Could not determine model name from llm_model. "
+            "Please specify 'model' in batch_config."
+        )
+
+    def _get_format_instructions(self) -> str:
+        """Get format instructions based on the schema configuration."""
+        if self.schema is not None:
+            output_parser = get_pydantic_output_parser(self.schema)
+            return output_parser.get_format_instructions()
+        return (
+            "You must respond with a JSON object. Your response should be "
+            "formatted as a valid JSON with a 'content' field containing "
+            'your analysis. For example:\n'
+            '{"content": "your analysis here"}'
+        )
+
+    def _build_prompt_text(
+        self,
+        user_prompt: str,
+        content: str,
+        format_instructions: str,
+    ) -> str:
+        """Build the full prompt text for a single document.
+
+        Args:
+            user_prompt: The user's question/prompt.
+            content: The scraped document content.
+            format_instructions: JSON output format instructions.
+
+        Returns:
+            The formatted prompt string.
+        """
+        template = (
+            TEMPLATE_NO_CHUNKS_MD
+            if self.is_md_scraper
+            else TEMPLATE_NO_CHUNKS
+        )
+
+        if self.additional_info:
+            template = self.additional_info + template
+
+        prompt = PromptTemplate(
+            template=template,
+            input_variables=["content", "question"],
+            partial_variables={"format_instructions": format_instructions},
+        )
+        return prompt.format(content=content, question=user_prompt)
+
+    def execute(self, state: dict) -> dict:
+        """Execute the batch generation node.
+
+        Takes multiple parsed documents and a user prompt, builds prompts
+        for each document, and submits them as a single OpenAI Batch API
+        request.
+
+        Args:
+            state (dict): Must contain:
+                - user_prompt: The user's question.
+                - parsed_docs: List of parsed document contents.
+                - urls: List of source URLs (for result mapping).
+
+        Returns:
+            dict: Updated state with 'results' key containing
+                  a list of answers (one per document).
+        """
+        self.logger.info(f"--- Executing {self.node_name} Node ---")
+
+        user_prompt = state.get("user_prompt", "")
+        parsed_docs = state.get("parsed_docs", [])
+        urls = state.get("urls", [])
+
+        if not parsed_docs:
+            raise ValueError("No parsed documents found in state")
+
+        model_name = self._get_model_name()
+        format_instructions = self._get_format_instructions()
+
+        # Build batch requests with doc_id → URL mapping
+        batch_requests = []
+        doc_id_to_url = {}
+
+        for i, doc in enumerate(parsed_docs):
+            custom_id = f"doc_{i:04d}"
+            doc_id_to_url[custom_id] = urls[i] if i < len(urls) else f"doc_{i}"
+
+            # Handle chunked documents — use first chunk for batch
+            content = doc[0] if isinstance(doc, list) and len(doc) == 1 else str(doc)
+
+            prompt_text = self._build_prompt_text(
+                user_prompt, content, format_instructions
+            )
+
+            batch_requests.append(BatchRequest(
+                custom_id=custom_id,
+                model=model_name,
+                messages=[{"role": "user", "content": prompt_text}],
+                temperature=self.batch_temperature,
+                response_format={"type": "json_object"},
+            ))
+
+        self.logger.info(
+            f"Submitting {len(batch_requests)} requests to "
+            f"OpenAI Batch API (model: {model_name})..."
+        )
+
+        # Submit batch
+        from openai import OpenAI
+
+        client = OpenAI()
+        batch_id = create_batch(
+            client,
+            batch_requests,
+            description=f"ScrapeGraphAI: {user_prompt[:100]}",
+        )
+
+        self.logger.info(f"Batch submitted: {batch_id}")
+        state["batch_id"] = batch_id
+
+        # Poll until complete
+        batch_info = poll_batch_until_complete(
+            client,
+            batch_id,
+            poll_interval=self.poll_interval,
+            max_wait_time=self.max_wait_time,
+        )
+
+        # Retrieve results
+        results = retrieve_batch_results(client, batch_info)
+
+        # Parse results back into answers, maintaining URL order
+        answers = []
+        for result in results:
+            if result.error:
+                self.logger.warning(
+                    f"Request {result.custom_id} "
+                    f"(URL: {doc_id_to_url.get(result.custom_id, 'unknown')}) "
+                    f"failed: {result.error}"
+                )
+                answers.append({"error": result.error})
+                continue
+
+            try:
+                parsed = json.loads(result.content)
+                answers.append(parsed)
+            except (json.JSONDecodeError, TypeError):
+                # If not valid JSON, wrap the raw content
+                answers.append({"content": result.content})
+
+        self.logger.info(
+            f"Batch complete: {len(answers)} answers retrieved "
+            f"({sum(1 for a in answers if 'error' not in a)} succeeded)"
+        )
+
+        state.update({
+            self.output[0]: answers,
+            "doc_id_to_url": doc_id_to_url,
+        })
+        return state

--- a/scrapegraphai/utils/batch_api.py
+++ b/scrapegraphai/utils/batch_api.py
@@ -1,0 +1,316 @@
+"""
+OpenAI Batch API utility functions.
+
+Provides helpers for creating, polling, and retrieving results
+from the OpenAI Batch API, enabling 50% cost savings on LLM calls
+when real-time responses are not needed.
+
+Reference: https://platform.openai.com/docs/guides/batch
+"""
+
+import io
+import json
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from openai import OpenAI
+
+logger = logging.getLogger(__name__)
+
+# OpenAI Batch API limits
+MAX_REQUESTS_PER_BATCH = 50_000
+DEFAULT_POLL_INTERVAL = 30  # seconds
+DEFAULT_MAX_WAIT_TIME = 86_400  # 24 hours
+
+
+@dataclass
+class BatchRequest:
+    """A single request within a batch submission."""
+
+    custom_id: str
+    """Unique identifier for mapping responses back to requests."""
+
+    model: str
+    """The OpenAI model to use (e.g., 'gpt-4o-mini')."""
+
+    messages: List[Dict[str, str]]
+    """The chat messages for this request."""
+
+    temperature: float = 0.0
+    """Sampling temperature."""
+
+    max_tokens: Optional[int] = None
+    """Maximum tokens in the response."""
+
+    response_format: Optional[Dict[str, str]] = None
+    """Optional response format (e.g., {"type": "json_object"})."""
+
+    def to_jsonl_line(self) -> str:
+        """Convert to a JSONL line for the Batch API input file."""
+        body = {
+            "model": self.model,
+            "messages": self.messages,
+            "temperature": self.temperature,
+        }
+        if self.max_tokens is not None:
+            body["max_tokens"] = self.max_tokens
+        if self.response_format is not None:
+            body["response_format"] = self.response_format
+
+        return json.dumps({
+            "custom_id": self.custom_id,
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": body,
+        })
+
+
+@dataclass
+class BatchResult:
+    """The result of a single request within a completed batch."""
+
+    custom_id: str
+    """The custom ID that was provided in the request."""
+
+    content: Optional[str] = None
+    """The response content from the LLM."""
+
+    error: Optional[str] = None
+    """Error message if this individual request failed."""
+
+    usage: Optional[Dict[str, int]] = None
+    """Token usage for this request."""
+
+
+@dataclass
+class BatchJobInfo:
+    """Status information about a batch job."""
+
+    batch_id: str
+    """The OpenAI batch ID."""
+
+    status: str
+    """Current status: validating, in_progress, completed, failed, expired, etc."""
+
+    total_requests: int = 0
+    """Total number of requests in the batch."""
+
+    completed_requests: int = 0
+    """Number of completed requests."""
+
+    failed_requests: int = 0
+    """Number of failed requests."""
+
+    output_file_id: Optional[str] = None
+    """ID of the output file when batch completes."""
+
+    error_file_id: Optional[str] = None
+    """ID of the error file if there are errors."""
+
+
+def create_batch(
+    client: OpenAI,
+    requests: List[BatchRequest],
+    description: str = "ScrapeGraphAI batch scraping job",
+) -> str:
+    """Create and submit an OpenAI Batch API job.
+
+    Args:
+        client: An initialized OpenAI client.
+        requests: List of BatchRequest objects to submit.
+        description: Human-readable description for the batch.
+
+    Returns:
+        The batch ID for tracking the job.
+
+    Raises:
+        ValueError: If the number of requests exceeds the API limit.
+    """
+    if len(requests) > MAX_REQUESTS_PER_BATCH:
+        raise ValueError(
+            f"Batch size {len(requests)} exceeds the maximum of "
+            f"{MAX_REQUESTS_PER_BATCH}. Split into multiple batches."
+        )
+
+    # Build JSONL content
+    jsonl_content = "\n".join(req.to_jsonl_line() for req in requests)
+
+    logger.info(
+        f"Uploading batch input file with {len(requests)} requests..."
+    )
+
+    # Upload the input file
+    input_file = client.files.create(
+        file=io.BytesIO(jsonl_content.encode("utf-8")),
+        purpose="batch",
+    )
+
+    logger.info(f"Input file uploaded: {input_file.id}")
+
+    # Create the batch
+    batch = client.batches.create(
+        input_file_id=input_file.id,
+        endpoint="/v1/chat/completions",
+        completion_window="24h",
+        metadata={"description": description},
+    )
+
+    logger.info(
+        f"Batch created: {batch.id} (status: {batch.status})"
+    )
+
+    return batch.id
+
+
+def get_batch_status(client: OpenAI, batch_id: str) -> BatchJobInfo:
+    """Get the current status of a batch job.
+
+    Args:
+        client: An initialized OpenAI client.
+        batch_id: The batch ID returned by create_batch.
+
+    Returns:
+        BatchJobInfo with the current status and counts.
+    """
+    batch = client.batches.retrieve(batch_id)
+
+    return BatchJobInfo(
+        batch_id=batch.id,
+        status=batch.status,
+        total_requests=batch.request_counts.total if batch.request_counts else 0,
+        completed_requests=batch.request_counts.completed if batch.request_counts else 0,
+        failed_requests=batch.request_counts.failed if batch.request_counts else 0,
+        output_file_id=batch.output_file_id,
+        error_file_id=batch.error_file_id,
+    )
+
+
+def poll_batch_until_complete(
+    client: OpenAI,
+    batch_id: str,
+    poll_interval: int = DEFAULT_POLL_INTERVAL,
+    max_wait_time: int = DEFAULT_MAX_WAIT_TIME,
+) -> BatchJobInfo:
+    """Poll a batch job until it completes, fails, or times out.
+
+    Args:
+        client: An initialized OpenAI client.
+        batch_id: The batch ID to poll.
+        poll_interval: Seconds between status checks.
+        max_wait_time: Maximum seconds to wait before giving up.
+
+    Returns:
+        Final BatchJobInfo when the batch reaches a terminal state.
+
+    Raises:
+        TimeoutError: If max_wait_time is exceeded.
+        RuntimeError: If the batch fails or is cancelled.
+    """
+    terminal_states = {"completed", "failed", "expired", "cancelled"}
+    start_time = time.time()
+
+    logger.info(
+        f"Polling batch {batch_id} every {poll_interval}s "
+        f"(max wait: {max_wait_time}s)..."
+    )
+
+    while True:
+        elapsed = time.time() - start_time
+        if elapsed > max_wait_time:
+            raise TimeoutError(
+                f"Batch {batch_id} did not complete within "
+                f"{max_wait_time}s (last status check at {elapsed:.0f}s)"
+            )
+
+        info = get_batch_status(client, batch_id)
+
+        logger.info(
+            f"Batch {batch_id}: {info.status} "
+            f"({info.completed_requests}/{info.total_requests} done, "
+            f"{info.failed_requests} failed)"
+        )
+
+        if info.status in terminal_states:
+            if info.status == "failed":
+                raise RuntimeError(
+                    f"Batch {batch_id} failed. "
+                    f"Error file: {info.error_file_id}"
+                )
+            if info.status in {"expired", "cancelled"}:
+                raise RuntimeError(
+                    f"Batch {batch_id} was {info.status}."
+                )
+            return info
+
+        time.sleep(poll_interval)
+
+
+def retrieve_batch_results(
+    client: OpenAI,
+    batch_info: BatchJobInfo,
+) -> List[BatchResult]:
+    """Retrieve and parse results from a completed batch.
+
+    Args:
+        client: An initialized OpenAI client.
+        batch_info: A BatchJobInfo from a completed batch.
+
+    Returns:
+        List of BatchResult objects, one per request,
+        ordered by their custom_id.
+    """
+    if not batch_info.output_file_id:
+        raise ValueError(
+            f"Batch {batch_info.batch_id} has no output file. "
+            f"Status: {batch_info.status}"
+        )
+
+    logger.info(f"Downloading results from {batch_info.output_file_id}...")
+
+    output_content = client.files.content(batch_info.output_file_id).text
+    results = []
+
+    for line in output_content.strip().split("\n"):
+        if not line:
+            continue
+
+        response_data = json.loads(line)
+        custom_id = response_data["custom_id"]
+
+        error = response_data.get("error")
+        if error:
+            results.append(BatchResult(
+                custom_id=custom_id,
+                error=json.dumps(error),
+            ))
+            continue
+
+        body = response_data.get("response", {}).get("body", {})
+        choices = body.get("choices", [])
+
+        if choices:
+            content = choices[0].get("message", {}).get("content", "")
+            usage = body.get("usage")
+            results.append(BatchResult(
+                custom_id=custom_id,
+                content=content,
+                usage=usage,
+            ))
+        else:
+            results.append(BatchResult(
+                custom_id=custom_id,
+                error="No choices returned in response",
+            ))
+
+    # Sort by custom_id to maintain order
+    results.sort(key=lambda r: r.custom_id)
+
+    logger.info(
+        f"Retrieved {len(results)} results "
+        f"({sum(1 for r in results if r.error is None)} succeeded, "
+        f"{sum(1 for r in results if r.error is not None)} failed)"
+    )
+
+    return results

--- a/tests/test_batch_api.py
+++ b/tests/test_batch_api.py
@@ -1,0 +1,403 @@
+"""
+Tests for the OpenAI Batch API integration.
+
+Tests cover:
+- batch_api.py utility functions
+- BatchGenerateAnswerNode
+- SmartScraperMultiBatchGraph initialization and validation
+"""
+
+import json
+
+import pytest
+
+from scrapegraphai.utils.batch_api import (
+    BatchJobInfo,
+    BatchRequest,
+    BatchResult,
+    retrieve_batch_results,
+)
+
+
+# ─── BatchRequest Tests ───
+
+
+class TestBatchRequest:
+    """Tests for the BatchRequest dataclass."""
+
+    def test_to_jsonl_line_basic(self):
+        """Test basic JSONL line generation."""
+        req = BatchRequest(
+            custom_id="doc_0000",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        line = req.to_jsonl_line()
+        data = json.loads(line)
+
+        assert data["custom_id"] == "doc_0000"
+        assert data["method"] == "POST"
+        assert data["url"] == "/v1/chat/completions"
+        assert data["body"]["model"] == "gpt-4o-mini"
+        assert data["body"]["messages"] == [{"role": "user", "content": "Hello"}]
+        assert data["body"]["temperature"] == 0.0
+
+    def test_to_jsonl_line_with_max_tokens(self):
+        """Test JSONL line with max_tokens specified."""
+        req = BatchRequest(
+            custom_id="doc_0001",
+            model="gpt-4o",
+            messages=[{"role": "user", "content": "Test"}],
+            max_tokens=500,
+        )
+        data = json.loads(req.to_jsonl_line())
+        assert data["body"]["max_tokens"] == 500
+
+    def test_to_jsonl_line_with_response_format(self):
+        """Test JSONL line with response_format specified."""
+        req = BatchRequest(
+            custom_id="doc_0002",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Extract"}],
+            response_format={"type": "json_object"},
+        )
+        data = json.loads(req.to_jsonl_line())
+        assert data["body"]["response_format"] == {"type": "json_object"}
+
+    def test_to_jsonl_line_without_optional_fields(self):
+        """Test that optional fields are excluded when None."""
+        req = BatchRequest(
+            custom_id="doc_0003",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Test"}],
+        )
+        data = json.loads(req.to_jsonl_line())
+        assert "max_tokens" not in data["body"]
+        assert "response_format" not in data["body"]
+
+    def test_to_jsonl_line_custom_temperature(self):
+        """Test custom temperature in JSONL output."""
+        req = BatchRequest(
+            custom_id="doc_0004",
+            model="gpt-4o-mini",
+            messages=[{"role": "user", "content": "Test"}],
+            temperature=0.7,
+        )
+        data = json.loads(req.to_jsonl_line())
+        assert data["body"]["temperature"] == 0.7
+
+
+# ─── BatchResult Tests ───
+
+
+class TestBatchResult:
+    """Tests for the BatchResult dataclass."""
+
+    def test_successful_result(self):
+        """Test creating a successful batch result."""
+        result = BatchResult(
+            custom_id="doc_0000",
+            content='{"key": "value"}',
+            usage={"prompt_tokens": 100, "completion_tokens": 50},
+        )
+        assert result.custom_id == "doc_0000"
+        assert result.content == '{"key": "value"}'
+        assert result.error is None
+        assert result.usage["prompt_tokens"] == 100
+
+    def test_failed_result(self):
+        """Test creating a failed batch result."""
+        result = BatchResult(
+            custom_id="doc_0001",
+            error="Rate limit exceeded",
+        )
+        assert result.custom_id == "doc_0001"
+        assert result.content is None
+        assert result.error == "Rate limit exceeded"
+
+
+# ─── BatchJobInfo Tests ───
+
+
+class TestBatchJobInfo:
+    """Tests for the BatchJobInfo dataclass."""
+
+    def test_completed_batch(self):
+        """Test a completed batch job info."""
+        info = BatchJobInfo(
+            batch_id="batch_123",
+            status="completed",
+            total_requests=10,
+            completed_requests=10,
+            failed_requests=0,
+            output_file_id="file-abc",
+        )
+        assert info.status == "completed"
+        assert info.total_requests == 10
+        assert info.failed_requests == 0
+
+    def test_in_progress_batch(self):
+        """Test an in-progress batch job info."""
+        info = BatchJobInfo(
+            batch_id="batch_456",
+            status="in_progress",
+            total_requests=100,
+            completed_requests=42,
+            failed_requests=1,
+        )
+        assert info.status == "in_progress"
+        assert info.completed_requests == 42
+        assert info.output_file_id is None
+
+
+# ─── retrieve_batch_results Tests ───
+
+
+class TestRetrieveBatchResults:
+    """Tests for result retrieval and parsing."""
+
+    def test_retrieve_no_output_file(self):
+        """Test that retrieval fails when no output file is available."""
+        info = BatchJobInfo(
+            batch_id="batch_789",
+            status="failed",
+            output_file_id=None,
+        )
+
+        class DummyClient:
+            pass
+
+        with pytest.raises(ValueError, match="no output file"):
+            retrieve_batch_results(DummyClient(), info)
+
+    def test_results_sorted_by_custom_id(self):
+        """Test that results are sorted by custom_id for consistent ordering."""
+        # Simulate results out of order
+        jsonl_output = "\n".join([
+            json.dumps({
+                "custom_id": "doc_0002",
+                "response": {
+                    "body": {
+                        "choices": [{"message": {"content": '{"val": "c"}'}}],
+                        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                    }
+                },
+            }),
+            json.dumps({
+                "custom_id": "doc_0000",
+                "response": {
+                    "body": {
+                        "choices": [{"message": {"content": '{"val": "a"}'}}],
+                        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                    }
+                },
+            }),
+            json.dumps({
+                "custom_id": "doc_0001",
+                "response": {
+                    "body": {
+                        "choices": [{"message": {"content": '{"val": "b"}'}}],
+                        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                    }
+                },
+            }),
+        ])
+
+        class DummyFileContent:
+            text = jsonl_output
+
+        class DummyFiles:
+            def content(self, file_id):
+                return DummyFileContent()
+
+        class DummyClient:
+            files = DummyFiles()
+
+        info = BatchJobInfo(
+            batch_id="batch_sorted",
+            status="completed",
+            output_file_id="file-sorted",
+        )
+
+        results = retrieve_batch_results(DummyClient(), info)
+
+        assert len(results) == 3
+        assert results[0].custom_id == "doc_0000"
+        assert results[1].custom_id == "doc_0001"
+        assert results[2].custom_id == "doc_0002"
+        assert results[0].content == '{"val": "a"}'
+
+    def test_handles_partial_failures(self):
+        """Test that partial failures in batch results are handled correctly."""
+        jsonl_output = "\n".join([
+            json.dumps({
+                "custom_id": "doc_0000",
+                "response": {
+                    "body": {
+                        "choices": [{"message": {"content": '{"result": "ok"}'}}],
+                    }
+                },
+            }),
+            json.dumps({
+                "custom_id": "doc_0001",
+                "error": {"code": "rate_limit", "message": "Too many requests"},
+            }),
+        ])
+
+        class DummyFileContent:
+            text = jsonl_output
+
+        class DummyFiles:
+            def content(self, file_id):
+                return DummyFileContent()
+
+        class DummyClient:
+            files = DummyFiles()
+
+        info = BatchJobInfo(
+            batch_id="batch_partial",
+            status="completed",
+            output_file_id="file-partial",
+        )
+
+        results = retrieve_batch_results(DummyClient(), info)
+
+        assert len(results) == 2
+        # doc_0000 succeeded
+        assert results[0].content == '{"result": "ok"}'
+        assert results[0].error is None
+        # doc_0001 failed
+        assert results[1].error is not None
+        assert results[1].content is None
+
+
+# ─── SmartScraperMultiBatchGraph Validation Tests ───
+
+
+class TestSmartScraperMultiBatchGraphValidation:
+    """Tests for SmartScraperMultiBatchGraph initialization validation."""
+
+    def test_rejects_non_openai_provider(self):
+        """Test that non-OpenAI providers are rejected."""
+        from scrapegraphai.graphs.smart_scraper_multi_batch_graph import (
+            SmartScraperMultiBatchGraph,
+        )
+
+        with pytest.raises(ValueError, match="only supports OpenAI"):
+            SmartScraperMultiBatchGraph(
+                prompt="Test prompt",
+                source=["https://example.com"],
+                config={"llm": {"model": "anthropic/claude-3"}},
+            )
+
+    def test_rejects_groq_provider(self):
+        """Test that Groq provider is rejected."""
+        from scrapegraphai.graphs.smart_scraper_multi_batch_graph import (
+            SmartScraperMultiBatchGraph,
+        )
+
+        with pytest.raises(ValueError, match="only supports OpenAI"):
+            SmartScraperMultiBatchGraph(
+                prompt="Test",
+                source=["https://example.com"],
+                config={"llm": {"model": "groq/llama-3"}},
+            )
+
+
+# ─── BatchGenerateAnswerNode Tests ───
+
+
+class TestBatchGenerateAnswerNode:
+    """Tests for the BatchGenerateAnswerNode."""
+
+    def test_empty_parsed_docs_raises(self):
+        """Test that empty parsed_docs raises ValueError."""
+        from scrapegraphai.nodes.batch_generate_answer_node import (
+            BatchGenerateAnswerNode,
+        )
+
+        class DummyLLM:
+            model_name = "gpt-4o-mini"
+
+        node = BatchGenerateAnswerNode(
+            input="user_prompt & parsed_docs",
+            output=["results"],
+            node_config={
+                "llm_model": DummyLLM(),
+                "batch_config": {},
+            },
+        )
+
+        class DummyLogger:
+            def info(self, msg):
+                pass
+            def error(self, msg):
+                pass
+            def warning(self, msg):
+                pass
+
+        node.logger = DummyLogger()
+        node.get_input_keys = lambda state: ["user_prompt", "parsed_docs"]
+
+        with pytest.raises(ValueError, match="No parsed documents"):
+            node.execute({
+                "user_prompt": "Test",
+                "parsed_docs": [],
+                "urls": [],
+            })
+
+    def test_model_name_extraction(self):
+        """Test model name is correctly extracted from LLM instance."""
+        from scrapegraphai.nodes.batch_generate_answer_node import (
+            BatchGenerateAnswerNode,
+        )
+
+        class DummyLLM:
+            model_name = "gpt-4o-mini"
+
+        node = BatchGenerateAnswerNode(
+            input="user_prompt & parsed_docs",
+            output=["results"],
+            node_config={"llm_model": DummyLLM(), "batch_config": {}},
+        )
+
+        assert node._get_model_name() == "gpt-4o-mini"
+
+    def test_batch_model_override(self):
+        """Test that batch_config model overrides the LLM model name."""
+        from scrapegraphai.nodes.batch_generate_answer_node import (
+            BatchGenerateAnswerNode,
+        )
+
+        class DummyLLM:
+            model_name = "gpt-4o-mini"
+
+        node = BatchGenerateAnswerNode(
+            input="user_prompt & parsed_docs",
+            output=["results"],
+            node_config={
+                "llm_model": DummyLLM(),
+                "batch_config": {"model": "gpt-4o"},
+            },
+        )
+
+        assert node._get_model_name() == "gpt-4o"
+
+    def test_format_instructions_without_schema(self):
+        """Test default format instructions when no schema is provided."""
+        from scrapegraphai.nodes.batch_generate_answer_node import (
+            BatchGenerateAnswerNode,
+        )
+
+        class DummyLLM:
+            model_name = "gpt-4o-mini"
+
+        node = BatchGenerateAnswerNode(
+            input="user_prompt & parsed_docs",
+            output=["results"],
+            node_config={"llm_model": DummyLLM(), "batch_config": {}},
+        )
+
+        instructions = node._get_format_instructions()
+        assert "JSON" in instructions
+        assert "content" in instructions


### PR DESCRIPTION
## Closes #1036

### Problem

`SmartScraperMultiGraph` makes individual synchronous LLM calls per URL. Users scraping many URLs pay full API pricing even when they don't need real-time results.

### Solution

Added `SmartScraperMultiBatchGraph` — a new graph that uses the [OpenAI Batch API](https://platform.openai.com/docs/guides/batch) for **~50% cost savings** on LLM calls.

### How it works

```
Phase 1: Fetch & Parse all URLs concurrently (existing GraphIteratorNode)
Phase 2: Collect all prompts → submit as single OpenAI Batch
Phase 3: Poll for completion → retrieve results  
Phase 4: Merge results (existing MergeAnswersNode)
```

### Usage

```python
from scrapegraphai.graphs import SmartScraperMultiBatchGraph

graph = SmartScraperMultiBatchGraph(
    prompt="Extract the main topic and key points",
    source=["https://example.com/page1", "https://example.com/page2"],
    config={
        "llm": {"model": "openai/gpt-4o-mini"},
        "batch_api": {
            "poll_interval": 30,       # seconds between status checks
            "max_wait_time": 86400,    # max 24h wait
        },
    },
)
result = graph.run()  # ~50% cheaper than SmartScraperMultiGraph
```

### Files added/changed

| File | Change |
|------|--------|
| `scrapegraphai/utils/batch_api.py` | **NEW** — OpenAI Batch API helpers (create, poll, retrieve) |
| `scrapegraphai/nodes/batch_generate_answer_node.py` | **NEW** — Collects prompts, submits batch, parses results |
| `scrapegraphai/graphs/smart_scraper_multi_batch_graph.py` | **NEW** — 3-phase pipeline orchestration |
| `scrapegraphai/graphs/__init__.py` | Export `SmartScraperMultiBatchGraph` |
| `scrapegraphai/nodes/__init__.py` | Export `BatchGenerateAnswerNode` |
| `tests/test_batch_api.py` | **NEW** — 18 unit tests |

### Key features

- **Per-domain doc_id → URL mapping** — responses are correctly mapped back even if returned out of order
- **Partial failure handling** — if one document fails in the batch, others still succeed
- **OpenAI-only validation** — rejects non-OpenAI providers with a clear error message
- **Configurable polling** — `poll_interval` and `max_wait_time` in `batch_api` config
- **Zero impact on existing code** — new graph class, existing `SmartScraperMultiGraph` is untouched

### Tests

18 unit tests covering:
- BatchRequest JSONL generation (5 tests)
- BatchResult/BatchJobInfo dataclasses (4 tests)
- Result retrieval, ordering, and partial failures (3 tests)
- Provider validation (2 tests)
- BatchGenerateAnswerNode configuration (4 tests)

All 18 passed ✅ with `uv run pytest tests/test_batch_api.py`