### PR TITLE
fix(nodes): update outdated ChatOllama import path to langchain_ollama

### DIFF
--- a/scrapegraphai/nodes/generate_answer_node.py
+++ b/scrapegraphai/nodes/generate_answer_node.py
@@ -8,7 +8,7 @@ from typing import List, Optional
 
 from langchain_core.prompts import PromptTemplate
 from langchain_aws import ChatBedrock
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.runnables import RunnableParallel
 from langchain_openai import ChatOpenAI

--- a/scrapegraphai/nodes/generate_answer_node_k_level.py
+++ b/scrapegraphai/nodes/generate_answer_node_k_level.py
@@ -5,7 +5,7 @@ GenerateAnswerNodeKLevel Module
 from typing import List, Optional
 
 from langchain_aws import ChatBedrock
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.prompts import PromptTemplate
 from langchain_core.runnables import RunnableParallel

--- a/scrapegraphai/nodes/generate_answer_omni_node.py
+++ b/scrapegraphai/nodes/generate_answer_omni_node.py
@@ -5,7 +5,7 @@ GenerateAnswerNode Module
 from typing import List, Optional
 
 from langchain_core.prompts import PromptTemplate
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_core.runnables import RunnableParallel
 from langchain_mistralai import ChatMistralAI

--- a/scrapegraphai/nodes/generate_code_node.py
+++ b/scrapegraphai/nodes/generate_code_node.py
@@ -13,7 +13,7 @@ from bs4 import BeautifulSoup
 from jsonschema import ValidationError as JSONSchemaValidationError
 from jsonschema import validate
 from langchain_classic.output_parsers import ResponseSchema, StructuredOutputParser
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import PromptTemplate
 

--- a/scrapegraphai/nodes/html_analyzer_node.py
+++ b/scrapegraphai/nodes/html_analyzer_node.py
@@ -5,7 +5,7 @@ HtmlAnalyzerNode Module
 from typing import List, Optional
 
 from langchain_core.prompts import PromptTemplate
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 from langchain_core.output_parsers import StrOutputParser
 
 from ..prompts import TEMPLATE_HTML_ANALYSIS, TEMPLATE_HTML_ANALYSIS_WITH_CONTEXT

--- a/scrapegraphai/nodes/merge_answers_node.py
+++ b/scrapegraphai/nodes/merge_answers_node.py
@@ -5,7 +5,7 @@ MergeAnswersNode Module
 from typing import List, Optional
 
 from langchain_core.prompts import PromptTemplate
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 from langchain_core.output_parsers import JsonOutputParser
 from langchain_mistralai import ChatMistralAI
 from langchain_openai import ChatOpenAI

--- a/scrapegraphai/nodes/prompt_refiner_node.py
+++ b/scrapegraphai/nodes/prompt_refiner_node.py
@@ -5,7 +5,7 @@ PromptRefinerNode Module
 from typing import List, Optional
 
 from langchain_core.prompts import PromptTemplate
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 from langchain_core.output_parsers import StrOutputParser
 
 from ..prompts import TEMPLATE_REFINER, TEMPLATE_REFINER_WITH_CONTEXT

--- a/scrapegraphai/nodes/reasoning_node.py
+++ b/scrapegraphai/nodes/reasoning_node.py
@@ -5,7 +5,7 @@ PromptRefinerNode Module
 from typing import List, Optional
 
 from langchain_core.prompts import PromptTemplate
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 from langchain_core.output_parsers import StrOutputParser
 
 from ..prompts import TEMPLATE_REASONING, TEMPLATE_REASONING_WITH_CONTEXT

--- a/scrapegraphai/nodes/search_internet_node.py
+++ b/scrapegraphai/nodes/search_internet_node.py
@@ -6,7 +6,7 @@ from typing import List, Optional
 
 from langchain_core.output_parsers import CommaSeparatedListOutputParser
 from langchain_core.prompts import PromptTemplate
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 
 from ..prompts import TEMPLATE_SEARCH_INTERNET
 from ..utils.research_web import search_on_web

--- a/tests/nodes/search_internet_node_test.py
+++ b/tests/nodes/search_internet_node_test.py
@@ -1,6 +1,6 @@
 import unittest
 
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 
 from scrapegraphai.nodes import SearchInternetNode
 

--- a/tests/nodes/search_link_node_test.py
+++ b/tests/nodes/search_link_node_test.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 import pytest
-from langchain_community.chat_models import ChatOllama
+from langchain_ollama import ChatOllama
 
 from scrapegraphai.nodes import SearchLinkNode
 


### PR DESCRIPTION
### 🐛 Problem
In recent versions of `langchain`, the `ChatOllama` class has been completely removed from the legacy `langchain_community.chat_models` module. 

As a result, importing graph elements triggers a fatal `ImportError: cannot import name 'ChatOllama' from 'langchain_community.chat_models'`, rendering the scraper completely unusable out-of-the-box.

### 🛠️ Solution
This PR systematically replaces the outdated import paths across all affected node and graph files to use the modern, officially supported `langchain_ollama` package instead. This guarantees full compatibility with the latest LangChain ecosystem ecosystem.