### PR TITLE
feat: upgrade MiniMax default model to M3

### DIFF
--- a/scrapegraphai/helpers/models_tokens.py
+++ b/scrapegraphai/helpers/models_tokens.py
@@ -408,12 +408,8 @@ models_tokens = {
         "grok-beta": 128000,
     },
     "minimax": {
+        "MiniMax-M3": 524288,
         "MiniMax-M2.7": 204000,
         "MiniMax-M2.7-highspeed": 204000,
-        "MiniMax-M1": 1000000,
-        "MiniMax-M1-40k": 40000,
-        "MiniMax-M2": 204000,
-        "MiniMax-M2.5": 204000,
-        "MiniMax-M2.5-highspeed": 204000,
     },
 }

--- a/tests/test_minimax_models.py
+++ b/tests/test_minimax_models.py
@@ -25,31 +25,38 @@ def models_tokens():
     return module.models_tokens
 
 
-def test_minimax_m27_in_model_list(models_tokens):
-    """MiniMax-M2.7 and MiniMax-M2.7-highspeed should be in the model list."""
+def test_minimax_m3_in_model_list(models_tokens):
+    """MiniMax-M3 should be in the model list."""
+    minimax_models = models_tokens["minimax"]
+    assert "MiniMax-M3" in minimax_models
+
+
+def test_minimax_m3_listed_first(models_tokens):
+    """MiniMax-M3 should be the first (default) model in the minimax dict."""
+    minimax_models = list(models_tokens["minimax"].keys())
+    assert minimax_models[0] == "MiniMax-M3"
+
+
+def test_minimax_m27_still_available(models_tokens):
+    """MiniMax-M2.7 and its highspeed variant should remain as legacy options."""
     minimax_models = models_tokens["minimax"]
     assert "MiniMax-M2.7" in minimax_models
     assert "MiniMax-M2.7-highspeed" in minimax_models
 
 
-def test_minimax_m27_listed_first(models_tokens):
-    """MiniMax-M2.7 should be the first model in the minimax dict."""
-    minimax_models = list(models_tokens["minimax"].keys())
-    assert minimax_models[0] == "MiniMax-M2.7"
-    assert minimax_models[1] == "MiniMax-M2.7-highspeed"
-
-
-def test_minimax_old_models_still_present(models_tokens):
-    """All previous MiniMax models should still be available."""
+def test_minimax_deprecated_models_removed(models_tokens):
+    """Older deprecated MiniMax models should be removed from the list."""
     minimax_models = models_tokens["minimax"]
-    assert "MiniMax-M2.5" in minimax_models
-    assert "MiniMax-M2.5-highspeed" in minimax_models
-    assert "MiniMax-M2" in minimax_models
-    assert "MiniMax-M1" in minimax_models
+    assert "MiniMax-M2.5" not in minimax_models
+    assert "MiniMax-M2.5-highspeed" not in minimax_models
+    assert "MiniMax-M2" not in minimax_models
+    assert "MiniMax-M1" not in minimax_models
+    assert "MiniMax-M1-40k" not in minimax_models
 
 
-def test_minimax_m27_token_limits(models_tokens):
-    """MiniMax-M2.7 models should have correct token limits."""
+def test_minimax_token_limits(models_tokens):
+    """MiniMax model token limits should match upstream documentation."""
     minimax_models = models_tokens["minimax"]
+    assert minimax_models["MiniMax-M3"] == 524288
     assert minimax_models["MiniMax-M2.7"] == 204000
     assert minimax_models["MiniMax-M2.7-highspeed"] == 204000


### PR DESCRIPTION
## Summary

Upgrade MiniMax model configuration to include the latest M3 model as the new default.

## Changes

- Add `MiniMax-M3` to the `minimax` model list (524,288 context window)
- Set `MiniMax-M3` as the new default (first entry in the dict, which is also what `abstract_graph._create_llm` picks up via `models_tokens` lookup)
- Retain `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` as legacy options
- Remove deprecated older versions (`MiniMax-M2.5`, `MiniMax-M2.5-highspeed`, `MiniMax-M2`, `MiniMax-M1`, `MiniMax-M1-40k`)
- Update `tests/test_minimax_models.py` to reflect the new default and the removed models

## Why

MiniMax-M3 is the new flagship model with a 512K context window and 128K max output, available through the same OpenAI-compatible endpoint already wired into `scrapegraphai/models/minimax.py`. Bumping the default keeps users on the current generation while keeping M2.7 around for anyone pinned to it.

## Testing

- Re-ran the assertions in `tests/test_minimax_models.py` against the updated `models_tokens` dict — all 5 pass.
- No changes to `minimax` wrapper, `abstract_graph` registration, or the docs/README mention (which is version-agnostic).