### PR TITLE
fix: lazy imports to prevent torchcodec FFmpeg DLL crash on Windows

### DIFF
--- a/scrapegraphai/docloaders/__init__.py
+++ b/scrapegraphai/docloaders/__init__.py
@@ -1,11 +1,26 @@
 """
 This module handles document loading functionalities for the ScrapeGraphAI application.
+
+Note: ChromiumLoader and PlasmateLoader are lazy-imported to avoid triggering
+torchcodec/FFmpeg DLL loading at import time (sentence_transformers -> torchcodec chain).
 """
 
 from .browser_base import browser_base_fetch
-from .chromium import ChromiumLoader
-from .plasmate import PlasmateLoader
 from .scrape_do import scrape_do_fetch
+
+_LAZY_MODULES = {
+    "ChromiumLoader": ".chromium",
+    "PlasmateLoader": ".plasmate",
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_MODULES:
+        import importlib
+        module = importlib.import_module(_LAZY_MODULES[name], __package__)
+        return getattr(module, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
 
 __all__ = [
     "browser_base_fetch",

--- a/scrapegraphai/docloaders/chromium.py
+++ b/scrapegraphai/docloaders/chromium.py
@@ -3,7 +3,6 @@ from typing import Any, AsyncIterator, Iterator, List, Optional, Union
 
 import aiohttp
 import async_timeout
-from langchain_community.document_loaders.base import BaseLoader
 from langchain_core.documents import Document
 
 from ..utils import Proxy, dynamic_import, get_logger, parse_or_search_proxy
@@ -11,7 +10,7 @@ from ..utils import Proxy, dynamic_import, get_logger, parse_or_search_proxy
 logger = get_logger("web-loader")
 
 
-class ChromiumLoader(BaseLoader):
+class ChromiumLoader:
     """Scrapes HTML pages from URLs using a (headless) instance of the
     Chromium web driver with proxy protection.
 
@@ -435,6 +434,14 @@ class ChromiumLoader(BaseLoader):
                     )
             finally:
                 await browser.close()
+
+    def load(self) -> List[Document]:
+        """Load all documents synchronously."""
+        return list(self.lazy_load())
+
+    async def aload(self) -> List[Document]:
+        """Load all documents asynchronously."""
+        return [doc async for doc in self.alazy_load()]
 
     def lazy_load(self) -> Iterator[Document]:
         """

--- a/scrapegraphai/nodes/fetch_node.py
+++ b/scrapegraphai/nodes/fetch_node.py
@@ -7,7 +7,6 @@ from typing import List, Optional
 import concurrent.futures
 
 import requests
-from langchain_community.document_loaders import PyPDFLoader
 from langchain_core.documents import Document
 from langchain_openai import AzureChatOpenAI, ChatOpenAI
 
@@ -182,6 +181,7 @@ class FetchNode(BaseNode):
         """
 
         if input_type == "pdf":
+            from langchain_community.document_loaders import PyPDFLoader
             loader = PyPDFLoader(source)
             # PyPDFLoader.load() can be blocking for large PDFs. Run it in a thread and
             # enforce the configured timeout if provided.

--- a/scrapegraphai/nodes/robots_node.py
+++ b/scrapegraphai/nodes/robots_node.py
@@ -7,7 +7,6 @@ from urllib.parse import urlparse
 
 from langchain_core.output_parsers import CommaSeparatedListOutputParser
 from langchain_core.prompts import PromptTemplate
-from langchain_community.document_loaders import AsyncChromiumLoader
 
 from ..helpers import robots_dictionary
 from ..prompts import TEMPLATE_ROBOT
@@ -90,6 +89,7 @@ class RobotsNode(BaseNode):
         else:
             parsed_url = urlparse(source)
             base_url = f"{parsed_url.scheme}://{parsed_url.netloc}"
+            from langchain_community.document_loaders import AsyncChromiumLoader
             loader = AsyncChromiumLoader(f"{base_url}/robots.txt")
             document = loader.load()
             if "ollama" in self.llm_model.model:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,23 @@ from pathlib import Path
 from typing import Any, Dict
 from unittest.mock import Mock
 
+import sys
+import types
+
 import pytest
 from dotenv import load_dotenv
+
+# Mock torchcodec to prevent FFmpeg DLL crashes at import time.
+# sentence_transformers -> torchcodec -> FFmpeg native DLLs can't load on some systems.
+_tc = types.ModuleType("torchcodec")
+_tc.__version__ = "0.0.0"
+_tc.__file__ = "<mock>"
+_tc.__spec__ = types.ModuleType("spec")
+_tc.__spec__.name = "torchcodec"
+_tc.__spec__.loader = None
+_tc.__spec__.submodule_search_locations = []
+if "torchcodec" not in sys.modules:
+    sys.modules["torchcodec"] = _tc
 
 # Load environment variables
 load_dotenv()


### PR DESCRIPTION
Backports #1089 (merged into `pre/beta`) to `main`.

## Description

On Windows systems without FFmpeg native DLLs, importing `BaseLoader` from `langchain_community.document_loaders.base` triggers the `sentence_transformers` → `torchcodec` → FFmpeg loading chain, which crashes with a DLL load error.

This PR fixes it via lazy imports:
1. Remove `BaseLoader` inheritance from `ChromiumLoader` (reimplements `load()`/`aload()`)
2. Lazy `__getattr__` in `docloaders/__init__.py` for `ChromiumLoader`/`PlasmateLoader`
3. Move `PyPDFLoader` and `AsyncChromiumLoader` imports into function bodies
4. Mock `torchcodec` in `tests/conftest.py` to prevent the crash during test import

## Notes

- Cherry-pick of the squashed commit from #1089; original author: @Ege-BULUT.
- Already merged into `pre/beta`; this brings only this fix to `main` (no other beta changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)