### PR TITLE
fix: pop model_tokens so it is not forwarded to the model client

### DIFF
--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -221,6 +221,9 @@ class AbstractGraph(ABC):
         else:
             self.model_token = llm_params["model_tokens"]
 
+        # Consumed by ScrapeGraphAI; must not be forwarded to the model client.
+        llm_params.pop("model_tokens", None)
+
         try:
             if llm_params["model_provider"] not in {
                 "oneapi",


### PR DESCRIPTION
## Description

Fixes #1099.

On the plain `llm`-config path, `AbstractGraph._create_llm()` reads `model_tokens` into `self.model_token` but never removes it from `llm_params`. `llm_params` is then splatted into `init_chat_model(**llm_params)`, so `model_tokens` is forwarded to the model client. With a `ChatOpenAI` client (any OpenAI-compatible `base_url`) this surfaces as:

```
TypeError: Completions.create() got an unexpected keyword argument 'model_tokens'. Did you mean 'max_tokens'?
```

This one-line change pops `model_tokens` after it is consumed, so it can't leak to the client. It mirrors the existing `model_instance` path, which already returns before the key can reach a client (and is why that path works today).

## Repro (before this patch)

```python
from scrapegraphai.graphs import SmartScraperGraph

graph_config = {
    "llm": {
        "api_key": "<key>",
        "model": "openai/gpt-4o-mini",
        "base_url": "https://<any-openai-compatible-endpoint>/v1",
        "model_tokens": 128000,
    },
}
SmartScraperGraph(prompt="Summarize", source="https://example.com", config=graph_config).run()
```

## Change

```python
else:
    self.model_token = llm_params["model_tokens"]

# Consumed by ScrapeGraphAI; must not be forwarded to the model client.
llm_params.pop("model_tokens", None)
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Notes

Verified locally against an OpenAI-compatible endpoint (Cloudflare AI Gateway `/compat`): with the patch, passing `model_tokens` via plain config no longer raises and the value is correctly used for chunk sizing.