### PR TITLE
feat: add OpenRouter provider with full dispatch wiring

### DIFF
--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -13,7 +13,7 @@ from langchain_core.rate_limiters import InMemoryRateLimiter
 from pydantic import BaseModel
 
 from ..helpers import models_tokens
-from ..models import XAI, CLoD, DeepSeek, MiniMax, Nvidia, OneApi
+from ..models import XAI, CLoD, DeepSeek, MiniMax, Nvidia, OneApi, OpenRouter
 from ..utils.logging import get_logger, set_verbosity_info, set_verbosity_warning
 
 logger = get_logger(__name__)
@@ -172,6 +172,7 @@ class AbstractGraph(ABC):
             "togetherai",
             "xai",
             "minimax",
+            "openrouter",
         }
 
         if "/" in llm_params["model"]:
@@ -253,6 +254,9 @@ class AbstractGraph(ABC):
 
                 if model_provider == "minimax":
                     return MiniMax(**llm_params)
+
+                if model_provider == "openrouter":
+                    return OpenRouter(**llm_params)
 
                 if model_provider == "ernie":
                     from langchain_community.chat_models import ErnieBotChat

--- a/scrapegraphai/helpers/models_tokens.py
+++ b/scrapegraphai/helpers/models_tokens.py
@@ -412,4 +412,15 @@ models_tokens = {
         "MiniMax-M2.7": 204000,
         "MiniMax-M2.7-highspeed": 204000,
     },
+    "openrouter": {
+        "openai/gpt-4o": 128000,
+        "openai/gpt-4o-mini": 128000,
+        "anthropic/claude-3.5-sonnet": 200000,
+        "anthropic/claude-3.5-haiku": 200000,
+        "google/gemini-2.0-flash-001": 1000000,
+        "meta-llama/llama-3.3-70b-instruct": 131072,
+        "deepseek/deepseek-chat": 128000,
+        "mistralai/mixtral-8x7b-instruct": 32768,
+        "qwen/qwen2.5-72b-instruct": 32768,
+    },
 }

--- a/scrapegraphai/models/__init__.py
+++ b/scrapegraphai/models/__init__.py
@@ -9,6 +9,7 @@ from .nvidia import Nvidia
 from .oneapi import OneApi
 from .openai_itt import OpenAIImageToText
 from .openai_tts import OpenAITextToSpeech
+from .openrouter import OpenRouter
 from .xai import XAI
 
-__all__ = ["DeepSeek", "MiniMax", "OneApi", "OpenAIImageToText", "OpenAITextToSpeech", "CLoD", "XAI", "Nvidia"]
+__all__ = ["DeepSeek", "MiniMax", "OneApi", "OpenAIImageToText", "OpenAITextToSpeech", "CLoD", "XAI", "Nvidia", "OpenRouter"]

--- a/scrapegraphai/models/openrouter.py
+++ b/scrapegraphai/models/openrouter.py
@@ -1,0 +1,21 @@
+"""OpenRouter Module"""
+from langchain_openai import ChatOpenAI
+
+
+class OpenRouter(ChatOpenAI):
+    """A wrapper for ChatOpenAI configured for OpenRouter's OpenAI-compatible API.
+
+    OpenRouter exposes hundreds of models (OpenAI, Anthropic, Google, Meta,
+    DeepSeek, Mistral, Qwen, ...) behind a single OpenAI-compatible endpoint.
+    Use it by prefixing the model with ``openrouter/`` in the graph
+    configuration, e.g. ``"openrouter/anthropic/claude-3.5-sonnet"``.
+
+    Args:
+        llm_config (dict): Configuration parameters for the language model.
+    """
+
+    def __init__(self, **llm_config):
+        if "api_key" in llm_config:
+            llm_config["openai_api_key"] = llm_config.pop("api_key")
+        llm_config["openai_api_base"] = "https://openrouter.ai/api/v1"
+        super().__init__(**llm_config)

--- a/tests/test_openrouter_model.py
+++ b/tests/test_openrouter_model.py
@@ -1,0 +1,27 @@
+"""Tests for the OpenRouter model configuration."""
+import importlib.util
+import os
+
+
+def test_openrouter_model_sets_openai_compatible_base_url():
+    """OpenRouter should map api_key and set the OpenRouter base URL."""
+    spec = importlib.util.spec_from_file_location(
+        "openrouter",
+        os.path.join(
+            os.path.dirname(__file__),
+            "..",
+            "scrapegraphai",
+            "models",
+            "openrouter.py",
+        ),
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    model = module.OpenRouter(
+        api_key="test-key",
+        model="openrouter/anthropic/claude-3.5-sonnet",
+    )
+
+    assert str(model.openai_api_base).rstrip("/") == "https://openrouter.ai/api/v1"
+    assert model.openai_api_key == "test-key"


### PR DESCRIPTION
Adds OpenRouter as a first-class provider (closes the openrouter support request, e.g. #274).

OpenRouter is an OpenAI-compatible gateway to hundreds of models. This PR:
- adds `scrapegraphai/models/openrouter.py` (ChatOpenAI wrapper, base URL `https://openrouter.ai/api/v1`)
- registers it in `models/__init__.py` and `helpers/models_tokens.py`
- **wires it into `graphs/abstract_graph._create_llm`** (adds `openrouter` to `known_providers` and the dispatch branch) so `model: "openrouter/<model>"` actually resolves. Without this wiring the provider class is never instantiated (the same gap left by the open Atlas Cloud PR #1104).
- adds `tests/test_openrouter_model.py` mirroring the Atlas Cloud test

Usage:
```python
graph_config = {"llm": {"model": "openrouter/anthropic/claude-3.5-sonnet", "api_key": OR_KEY}, ...}
```

Low risk: additive, mirrors the existing DeepSeek/OneApi pattern, and falls back to 8192 tokens if a model is not in the token table.