### PR TITLE
fix: SmartScraperGraph returns NA/blank for all fields (#1102)

### DIFF
--- a/scrapegraphai/nodes/fetch_node.py
+++ b/scrapegraphai/nodes/fetch_node.py
@@ -291,15 +291,18 @@ class FetchNode(BaseNode):
                 if not response.text.strip():
                     raise ValueError("No HTML body content found in the response.")
 
-                if not self.cut:
-                    parsed_content = cleanup_html(response, source)
+                if self.cut:
+                    parsed_content = response.text
+                else:
+                    result = cleanup_html(response.text, source)
+                    parsed_content = result[1] if isinstance(result, tuple) else result
 
                 if (
                     isinstance(self.llm_model, (ChatOpenAI, AzureChatOpenAI))
                     and not self.script_creator
                     or (self.force and not self.script_creator)
                 ):
-                    parsed_content = convert_to_md(source, parsed_content)
+                    parsed_content = convert_to_md(parsed_content, source)
 
                 compressed_document = [Document(page_content=parsed_content)]
             else:
@@ -395,12 +398,12 @@ class FetchNode(BaseNode):
                 and not self.script_creator
                 and not self.openai_md_enabled
             ):
-                parsed_content = convert_to_md(document[0].page_content, parsed_content)
+                parsed_content = convert_to_md(document[0].page_content, source)
 
             compressed_document = [
                 Document(page_content=parsed_content, metadata={"source": "html file"})
             ]
-        state["doc"] = document
+            state["doc"] = document
         state.update(
             {
                 self.output[0]: compressed_document,

--- a/scrapegraphai/nodes/generate_answer_csv_node.py
+++ b/scrapegraphai/nodes/generate_answer_csv_node.py
@@ -127,7 +127,7 @@ class GenerateAnswerCSVNode(BaseNode):
                 template=TEMPLATE_NO_CHUKS_CSV_PROMPT,
                 input_variables=["question"],
                 partial_variables={
-                    "context": doc,
+                    "context": doc[0],
                     "format_instructions": format_instructions,
                 },
             )

--- a/scrapegraphai/nodes/generate_answer_node.py
+++ b/scrapegraphai/nodes/generate_answer_node.py
@@ -152,9 +152,9 @@ class GenerateAnswerNode(BaseNode):
             if not isinstance(self.llm_model, ChatBedrock):
                 output_parser = TolerantJsonOutputParser()
                 format_instructions = (
-                    "You must respond with a JSON object. Your response should be formatted as a valid JSON "
-                    "with a 'content' field containing your analysis. For example:\n"
-                    '{{"content": "your analysis here"}}'
+                    "You must respond with a valid JSON object. "
+                    "Determine the JSON keys and structure based on what the user's question asks for. "
+                    "Do not use a 'content' wrapper field - output the requested keys directly."
                 )
             else:
                 output_parser = None
@@ -193,7 +193,7 @@ class GenerateAnswerNode(BaseNode):
 
             try:
                 answer = self.invoke_with_timeout(
-                    chain, {"content": doc, "question": user_prompt}, self.timeout
+                    chain, {"content": doc[0], "question": user_prompt}, self.timeout
                 )
             except (Timeout, json.JSONDecodeError) as e:
                 error_msg = (

--- a/scrapegraphai/nodes/generate_answer_omni_node.py
+++ b/scrapegraphai/nodes/generate_answer_omni_node.py
@@ -125,7 +125,7 @@ class GenerateAnswerOmniNode(BaseNode):
                 template=TEMPLATE_NO_CHUNKS_OMNI_prompt,
                 input_variables=["question"],
                 partial_variables={
-                    "context": doc,
+                    "context": doc[0],
                     "format_instructions": format_instructions,
                     "img_desc": imag_desc,
                 },


### PR DESCRIPTION
## Summary

SmartScraperGraph returned "NA" for every requested field even on pages with clearly present content (Wikipedia infobox, etc). Content survived the fetch/parse pipeline but was rendered as a Python list repr in the LLM prompt, causing the model to fall back to "NA".

## Root cause

**Bug #1 (primary):** In `generate_answer_node.py:194`, the single-chunk path passed `doc` (a `List[str]`) as the `content` variable to the prompt template. LangChain rendered this as `['text...']` — a Python list repr with escaped `\n`. The LLM saw garbled content and returned "NA".

**Bug #2 (amplifier):** Default `format_instructions` forced a `{"content": "..."}` wrapper around the output, conflicting with the user's requested JSON keys. This confused the LLM further, triggering the "If you don't find the answer put as value NA" escape hatch.

**Bug #3-7:** Various `fetch_node.py` issues in the `use_soup=True` path (completely broken by default) and incorrect `convert_to_md` argument order.

## Changes (4 files, +14/-11)

### Content passing fixes
- `generate_answer_node.py:194`: `doc` -> `doc[0]` — LLM gets clean string
- `generate_answer_csv_node.py:130`: `doc` -> `doc[0]` — same fix
- `generate_answer_omni_node.py:128`: `doc` -> `doc[0]` — same fix

### Format instructions fix
- `generate_answer_node.py:152-156`: Remove hardcoded `{"content": ...}` wrapper. LLM now derives JSON keys from the user's question directly.

### FetchNode bug fixes
- `fetch_node.py:302`: `convert_to_md(source, parsed_content)` -> `convert_to_md(parsed_content, source)` — args were swapped (URL passed as HTML, content as URL)
- `fetch_node.py:398`: `convert_to_md(doc.page_content, parsed_content)` -> `convert_to_md(doc.page_content, source)` — pass actual URL, not identical HTML copy, for relative link resolution
- `fetch_node.py:294-298`: `use_soup` path — `parsed_content` was unbound when `cut=True` (default); fixed unconditional assignment + `cleanup_html(response.text, source)` not `cleanup_html(response, source)` (was passing Response object). Also `cleanup_html` returns tuple, so extract body at `[1]`
- `fetch_node.py:406`: Move `state["doc"] = document` inside `else` block — `document` is undefined in `use_soup=True` path

## Verification
- Content confirmed to reach LLM in clean string format (tested with real Wikipedia HTML, 1MB page)
- `convert_to_md` arg order verified against function signature
- All callers checked: 4 total, only 2 changed (other 2 unaffected)
- Pre-existing test suite: all pass (pre-existing failures unrelated)
