### PR TITLE
Fix SearchGraph silent failure: raise clear error + retry transient search blocks

### DIFF
--- a/scrapegraphai/graphs/search_graph.py
+++ b/scrapegraphai/graphs/search_graph.py
@@ -14,6 +14,20 @@ from .base_graph import BaseGraph
 from .smart_scraper_graph import SmartScraperGraph
 
 
+class SearchGraphEmptyAnswerError(ValueError):
+    """Raised when SearchGraph completes but yields no usable answer.
+
+    This replaces the previous silent ``"No answer found."`` return so callers can
+    tell a real failure (blocked search, 403/CAPTCHA on every URL, empty pages,
+    exhausted model quota) apart from a genuine empty result. The considered URLs
+    are attached so callers can inspect what was actually attempted.
+    """
+
+    def __init__(self, message: str, considered_urls: Optional[List[str]] = None):
+        super().__init__(message)
+        self.considered_urls: List[str] = considered_urls or []
+
+
 class SearchGraph(AbstractGraph):
     """
     SearchGraph is a scraping pipeline that searches the internet for answers to a given prompt.
@@ -71,6 +85,7 @@ class SearchGraph(AbstractGraph):
                 "storage_state": self.copy_config.get("storage_state"),
                 "search_engine": self.copy_config.get("search_engine"),
                 "serper_api_key": self.copy_config.get("serper_api_key"),
+                "max_retries": self.copy_config.get("max_retries", 1),
             },
         )
 
@@ -106,6 +121,12 @@ class SearchGraph(AbstractGraph):
 
         Returns:
             str: The answer to the prompt.
+
+        Raises:
+            SearchGraphEmptyAnswerError: If the graph completes but produces no
+                usable answer. This surfaces what used to be a silent
+                ``"No answer found."`` return so callers can distinguish a
+                configuration/blocking problem from a genuine empty result.
         """
 
         inputs = {"user_prompt": self.prompt}
@@ -115,7 +136,28 @@ class SearchGraph(AbstractGraph):
         if "urls" in self.final_state:
             self.considered_urls = self.final_state["urls"]
 
-        return self.final_state.get("answer", "No answer found.")
+        answer = self.final_state.get("answer")
+        considered = self.considered_urls or []
+
+        if not answer or (isinstance(answer, str) and answer.strip() == ""):
+            if not considered:
+                raise SearchGraphEmptyAnswerError(
+                    "SearchGraph finished but produced no answer and no URLs were "
+                    "considered. The search engine likely returned nothing "
+                    "(blocked, rate-limited, or the query matched no results). "
+                    "Check your search_engine / proxy / API key configuration.",
+                    considered_urls=considered,
+                )
+            raise SearchGraphEmptyAnswerError(
+                f"SearchGraph finished but produced no answer after considering "
+                f"{len(considered)} URL(s). The scraper or LLM likely returned "
+                f"empty for every source (commonly 403/CAPTCHA blocking, JS-only "
+                f"pages, or an exhausted model quota). Try a proxy, a headless "
+                f"browser, or inspect the sources. Considered URLs: {considered}",
+                considered_urls=considered,
+            )
+
+        return answer
 
     def get_considered_urls(self) -> List[str]:
         """

--- a/scrapegraphai/nodes/search_internet_node.py
+++ b/scrapegraphai/nodes/search_internet_node.py
@@ -56,6 +56,7 @@ class SearchInternetNode(BaseNode):
         )
 
         self.max_results = node_config.get("max_results", 3)
+        self.max_retries = node_config.get("max_retries", 1)
 
     def execute(self, state: dict) -> dict:
         """
@@ -108,6 +109,7 @@ class SearchInternetNode(BaseNode):
             search_engine=self.search_engine,
             proxy=self.proxy,
             serper_api_key=self.serper_api_key,
+            max_retries=self.max_retries,
         )
 
         if len(answer) == 0:

--- a/scrapegraphai/utils/research_web.py
+++ b/scrapegraphai/utils/research_web.py
@@ -58,6 +58,9 @@ class SearchConfig(BaseModel):
     serper_api_key: Optional[str] = Field(None, description="API key for Serper")
     region: Optional[str] = Field(None, description="Country/region code")
     language: str = Field("en", description="Language code")
+    max_retries: int = Field(
+        1, description="Retries on transient failures (403/rate-limit)"
+    )
 
     @validator("search_engine")
     def validate_search_engine(cls, v):
@@ -81,6 +84,13 @@ class SearchConfig(BaseModel):
         """Validate max results."""
         if v < 1 or v > 100:
             raise ValueError("max_results must be between 1 and 100")
+        return v
+
+    @validator("max_retries")
+    def validate_max_retries(cls, v):
+        """Validate max retries."""
+        if v < 0 or v > 5:
+            raise ValueError("max_retries must be between 0 and 5")
         return v
 
 
@@ -156,6 +166,33 @@ def get_random_user_agent() -> str:
     return random.choice(USER_AGENTS)
 
 
+def _run_with_retries(func, max_retries: int):
+    """Run ``func`` retrying transient failures with exponential backoff.
+
+    Args:
+        func: Zero-argument callable performing the search.
+        max_retries: Extra attempts after the first failure.
+
+    Returns:
+        The result of ``func``.
+
+    Raises:
+        SearchRequestError: If every attempt fails, wrapping the last error.
+    """
+    last_exc = None
+    for attempt in range(max_retries + 1):
+        try:
+            return func()
+        except Exception as exc:  # noqa: BLE001 - normalise to SearchRequestError
+            last_exc = exc
+            if attempt < max_retries:
+                time.sleep(min(2 ** attempt, 8))
+                continue
+    raise SearchRequestError(
+        f"Search failed after {max_retries + 1} attempt(s): {last_exc}"
+    )
+
+
 @rate_limited(calls=10, period=60)
 def search_on_web(
     query: str,
@@ -167,6 +204,7 @@ def search_on_web(
     serper_api_key: Optional[str] = None,
     region: Optional[str] = None,
     language: str = "en",
+    max_retries: int = 1,
 ) -> List[str]:
     """
     Search web function with improved error handling, validation, and security features.
@@ -205,6 +243,7 @@ def search_on_web(
             serper_api_key=serper_api_key,
             region=region,
             language=language,
+            max_retries=max_retries,
         )
 
         # Format proxy once
@@ -215,22 +254,34 @@ def search_on_web(
         results = []
         if config.search_engine == "duckduckgo":
             results = _search_duckduckgo(
-                config.query, config.max_results, formatted_proxy
+                config.query, config.max_results, formatted_proxy, config.max_retries
             )
 
         elif config.search_engine == "bing":
             results = _search_bing(
-                config.query, config.max_results, config.timeout, formatted_proxy
+                config.query,
+                config.max_results,
+                config.timeout,
+                formatted_proxy,
+                config.max_retries,
             )
 
         elif config.search_engine == "searxng":
             results = _search_searxng(
-                config.query, config.max_results, config.port, config.timeout
+                config.query,
+                config.max_results,
+                config.port,
+                config.timeout,
+                config.max_retries,
             )
 
         elif config.search_engine == "serper":
             results = _search_serper(
-                config.query, config.max_results, config.serper_api_key, config.timeout
+                config.query,
+                config.max_results,
+                config.serper_api_key,
+                config.timeout,
+                config.max_retries,
             )
 
         return filter_pdf_links(results)
@@ -244,7 +295,7 @@ def search_on_web(
 
 
 def _search_duckduckgo(
-    query: str, max_results: int, proxy: Optional[str] = None
+    query: str, max_results: int, proxy: Optional[str] = None, max_retries: int = 1
 ) -> List[str]:
     """
     Helper function for DuckDuckGo search using the ``ddgs`` package.
@@ -253,11 +304,14 @@ def _search_duckduckgo(
     ``langchain-community`` releases import ``from ddgs import DDGS``, which
     silently broke the previous langchain-based implementation. This calls
     ``ddgs`` directly so results no longer depend on parsing a formatted string.
+    Transient failures (rate-limiting, blocked requests) are retried with
+    exponential backoff.
 
     Args:
         query (str): Search query
         max_results (int): Maximum number of results to return
         proxy (str, optional): Proxy configuration
+        max_retries (int): Extra attempts on transient failure
 
     Returns:
         List[str]: List of URLs from search results
@@ -270,20 +324,19 @@ def _search_duckduckgo(
             "search. Please install it with `pip install -U ddgs`."
         ) from e
 
-    try:
+    def _once():
         with DDGS(proxy=proxy) as ddgs:
-            results = [
+            return [
                 result["href"]
                 for result in ddgs.text(query, max_results=max_results)
                 if result.get("href")
             ]
-        return results
-    except Exception as e:
-        raise SearchRequestError(f"DuckDuckGo search failed: {str(e)}")
+
+    return _run_with_retries(_once, max_retries)
 
 
 def _search_bing(
-    query: str, max_results: int, timeout: int, proxy: Optional[str] = None
+    query: str, max_results: int, timeout: int, proxy: Optional[str] = None, max_retries: int = 1
 ) -> List[str]:
     """
     Helper function for Bing search with improved error handling.
@@ -293,17 +346,16 @@ def _search_bing(
         max_results (int): Maximum number of results to return
         timeout (int): Request timeout in seconds
         proxy (str, optional): Proxy configuration
+        max_retries (int): Extra attempts on transient failure
 
     Returns:
         List[str]: List of URLs from search results
     """
-    headers = {"User-Agent": get_random_user_agent()}
 
-    params = {"q": query, "count": max_results}
-
-    proxies = {"http": proxy, "https": proxy} if proxy else None
-
-    try:
+    def _once():
+        headers = {"User-Agent": get_random_user_agent()}
+        params = {"q": query, "count": max_results}
+        proxies = {"http": proxy, "https": proxy} if proxy else None
         response = requests.get(
             "https://www.bing.com/search",
             params=params,
@@ -325,11 +377,11 @@ def _search_bing(
                     break
 
         return results
-    except Exception as e:
-        raise SearchRequestError(f"Bing search failed: {str(e)}")
+
+    return _run_with_retries(_once, max_retries)
 
 
-def _search_searxng(query: str, max_results: int, port: int, timeout: int) -> List[str]:
+def _search_searxng(query: str, max_results: int, port: int, timeout: int, max_retries: int = 1) -> List[str]:
     """
     Helper function for SearXNG search.
 
@@ -338,23 +390,23 @@ def _search_searxng(query: str, max_results: int, port: int, timeout: int) -> Li
         max_results (int): Maximum number of results to return
         port (int): Port for SearXNG
         timeout (int): Request timeout in seconds
+        max_retries (int): Extra attempts on transient failure
 
     Returns:
         List[str]: List of URLs from search results
     """
-    headers = {"User-Agent": get_random_user_agent()}
 
-    params = {
-        "q": query,
-        "format": "json",
-        "categories": "general",
-        "language": "en",
-        "time_range": "",
-        "engines": "duckduckgo,bing,brave",
-        "results": max_results,
-    }
-
-    try:
+    def _once():
+        headers = {"User-Agent": get_random_user_agent()}
+        params = {
+            "q": query,
+            "format": "json",
+            "categories": "general",
+            "language": "en",
+            "time_range": "",
+            "engines": "duckduckgo,bing,brave",
+            "results": max_results,
+        }
         response = requests.get(
             f"http://localhost:{port}/search",
             params=params,
@@ -366,12 +418,12 @@ def _search_searxng(query: str, max_results: int, port: int, timeout: int) -> Li
         json_data = response.json()
         results = [result["url"] for result in json_data.get("results", [])]
         return results[:max_results]
-    except Exception as e:
-        raise SearchRequestError(f"SearXNG search failed: {str(e)}")
+
+    return _run_with_retries(_once, max_retries)
 
 
 def _search_serper(
-    query: str, max_results: int, api_key: str, timeout: int
+    query: str, max_results: int, api_key: str, timeout: int, max_retries: int = 1
 ) -> List[str]:
     """
     Helper function for Serper search.
@@ -381,6 +433,7 @@ def _search_serper(
         max_results (int): Maximum number of results to return
         api_key (str): API key for Serper
         timeout (int): Request timeout in seconds
+        max_retries (int): Extra attempts on transient failure
 
     Returns:
         List[str]: List of URLs from search results
@@ -388,11 +441,9 @@ def _search_serper(
     if not api_key:
         raise SearchConfigError("Serper API key is required")
 
-    headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
-
-    data = {"q": query, "num": max_results}
-
-    try:
+    def _once():
+        headers = {"X-API-KEY": api_key, "Content-Type": "application/json"}
+        data = {"q": query, "num": max_results}
         response = requests.post(
             "https://google.serper.dev/search",
             json=data,
@@ -412,8 +463,8 @@ def _search_serper(
                     break
 
         return results
-    except Exception as e:
-        raise SearchRequestError(f"Serper search failed: {str(e)}")
+
+    return _run_with_retries(_once, max_retries)
 
 
 def format_proxy(proxy_config: Union[str, Dict, ProxyConfig]) -> str:

--- a/tests/test_search_graph.py
+++ b/tests/test_search_graph.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from scrapegraphai.graphs.search_graph import SearchGraph
+from scrapegraphai.graphs.search_graph import SearchGraph, SearchGraphEmptyAnswerError
 
 
 class TestSearchGraph:
@@ -27,7 +27,7 @@ class TestSearchGraph:
         mock_create_llm.return_value = MagicMock()
 
         # Mock the execute method to set the final_state
-        mock_base_graph.return_value.execute.return_value = ({"urls": urls}, {})
+        mock_base_graph.return_value.execute.return_value = ({"urls": urls, "answer": "ok"}, {})
 
         # Act
         search_graph = SearchGraph(prompt, config)
@@ -53,12 +53,32 @@ class TestSearchGraph:
         # Mock the execute method to set the final_state without an "answer" key
         mock_base_graph.return_value.execute.return_value = ({"urls": []}, {})
 
-        # Act
+        # Act / Assert: silent "No answer found." is now a clear exception
         search_graph = SearchGraph(prompt, config)
-        result = search_graph.run()
+        with pytest.raises(SearchGraphEmptyAnswerError) as exc_info:
+            search_graph.run()
+        assert "no URLs were considered" in str(exc_info.value)
+        assert exc_info.value.considered_urls == []
 
-        # Assert
-        assert result == "No answer found."
+    @patch("scrapegraphai.graphs.search_graph.BaseGraph")
+    @patch("scrapegraphai.graphs.abstract_graph.AbstractGraph._create_llm")
+    def test_run_empty_answer_with_urls_raises(self, mock_create_llm, mock_base_graph):
+        """
+        When URLs were considered but the scraper/LLM produced no answer,
+        run() must surface a clear error (not a silent "No answer found.").
+        """
+        prompt = "Test prompt"
+        config = {"llm": {"model": "test-model"}}
+        urls = ["https://a.com", "https://b.com"]
+
+        mock_create_llm.return_value = MagicMock()
+        mock_base_graph.return_value.execute.return_value = ({"urls": urls}, {})
+
+        search_graph = SearchGraph(prompt, config)
+        with pytest.raises(SearchGraphEmptyAnswerError) as exc_info:
+            search_graph.run()
+        assert exc_info.value.considered_urls == urls
+        assert "2 URL(s)" in str(exc_info.value)
 
     @patch("scrapegraphai.graphs.search_graph.SearchInternetNode")
     @patch("scrapegraphai.graphs.search_graph.GraphIteratorNode")

--- a/tests/utils/research_web_retry_test.py
+++ b/tests/utils/research_web_retry_test.py
@@ -1,0 +1,101 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+from scrapegraphai.utils.research_web import (
+    SearchRequestError,
+    _run_with_retries,
+    get_random_user_agent,
+    search_on_web,
+)
+
+
+def test_run_with_retries_succeeds_after_failures():
+    calls = {"n": 0}
+
+    def flaky():
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise SearchRequestError("transient")
+        return "ok"
+
+    assert _run_with_retries(flaky, max_retries=2) == "ok"
+    assert calls["n"] == 3
+
+
+def test_run_with_retries_exhausted_raises():
+    calls = {"n": 0}
+
+    def always_fail():
+        calls["n"] += 1
+        raise SearchRequestError("boom")
+
+    with pytest.raises(SearchRequestError):
+        _run_with_retries(always_fail, max_retries=2)
+    assert calls["n"] == 3
+
+
+def test_run_with_retries_zero_retries_no_retry():
+    calls = {"n": 0}
+
+    def always_fail():
+        calls["n"] += 1
+        raise SearchRequestError("boom")
+
+    with pytest.raises(SearchRequestError):
+        _run_with_retries(always_fail, max_retries=0)
+    assert calls["n"] == 1
+
+
+@patch("scrapegraphai.utils.research_web.requests.get")
+def test_search_on_web_retries_then_succeeds(mock_get):
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = "<html></html>"
+    resp.raise_for_status = MagicMock()
+    # First attempt is blocked (raises), second succeeds
+    mock_get.side_effect = [Exception("403 blocked"), resp]
+    result = search_on_web("query", search_engine="bing", max_results=1, max_retries=1)
+    assert result == []
+    assert mock_get.call_count == 2
+
+
+@patch("scrapegraphai.utils.research_web.requests.get")
+def test_search_on_web_retries_exhausted(mock_get):
+    mock_get.side_effect = Exception("403 blocked")
+    with pytest.raises(SearchRequestError):
+        search_on_web("query", search_engine="bing", max_results=1, max_retries=2)
+    assert mock_get.call_count == 3
+
+
+@patch("scrapegraphai.utils.research_web.requests.get")
+@patch("scrapegraphai.utils.research_web.get_random_user_agent")
+def test_search_bing_uses_random_user_agent(mock_ua, mock_get):
+    mock_ua.return_value = "UA-TEST"
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = "<html></html>"
+    resp.raise_for_status = MagicMock()
+    mock_get.return_value = resp
+
+    results = search_on_web("query", search_engine="bing", max_results=1, max_retries=0)
+    assert results == []
+    mock_ua.assert_called()
+    _, kwargs = mock_get.call_args
+    assert kwargs["headers"]["User-Agent"] == "UA-TEST"
+
+
+@patch("scrapegraphai.utils.research_web.requests.get")
+@patch("scrapegraphai.utils.research_web.get_random_user_agent")
+def test_search_bing_rotates_ua_on_retry(mock_ua, mock_get):
+    mock_ua.side_effect = ["UA-1", "UA-2"]
+    resp = MagicMock()
+    resp.status_code = 200
+    resp.text = "<html></html>"
+    resp.raise_for_status = MagicMock()
+    # First attempt is blocked (raises), second succeeds
+    mock_get.side_effect = [Exception("403 blocked"), resp]
+
+    search_on_web("query", search_engine="bing", max_results=1, max_retries=1)
+
+    assert mock_ua.call_count == 2
+    assert mock_get.call_count == 2


### PR DESCRIPTION
## Summary
Fixes the long-standing silent-failure behavior behind #1110 ("empty output / NA").

### SearchGraph no longer fails silently
- `SearchGraph.run()` used to return the opaque string `"No answer found."` whenever the graph produced no answer (e.g. search returned nothing, or every considered URL was blocked / returned empty). It now raises a dedicated `SearchGraphEmptyAnswerError` that includes the list of considered URLs, so callers can tell a real blocking/configuration problem apart from a genuine empty result.

### Search layer is more resilient to anti-bot blocks
- `search_on_web` gains a `max_retries` parameter (default 1) with exponential backoff. Bing / SearXNG rotate the User-Agent on every retry attempt.
- Transient `403` / rate-limit failures are retried before surfacing a clear `SearchRequestError`.

### Tests
- Updated `tests/test_search_graph.py` to assert the new exception behavior (including the with-URLs case).
- Added `tests/utils/research_web_retry_test.py` covering the retry mechanism, exhausted-retry raising, and UA rotation on retry (all mock-based, no network).

Related to #1110.