### PR TITLE
fix: allow running graphs inside an existing event loop (Jupyter, FastAPI)

### DIFF
--- a/scrapegraphai/docloaders/browser_base.py
+++ b/scrapegraphai/docloaders/browser_base.py
@@ -5,6 +5,8 @@ browserbase integration module
 import asyncio
 from typing import List
 
+from ..utils.event_loop import run_coroutine_sync
+
 
 def browser_base_fetch(
     api_key: str,
@@ -53,7 +55,7 @@ def browser_base_fetch(
                 result.append(await _async_fetch_link(url))
             return result
 
-        result = asyncio.run(_async_browser_base_fetch())
+        result = run_coroutine_sync(_async_browser_base_fetch())
     else:
         for url in link:
             result.append(session.load(url, text_content=text_content))

--- a/scrapegraphai/docloaders/chromium.py
+++ b/scrapegraphai/docloaders/chromium.py
@@ -6,6 +6,7 @@ import async_timeout
 from langchain_core.documents import Document
 
 from ..utils import Proxy, dynamic_import, get_logger, parse_or_search_proxy
+from ..utils.event_loop import run_coroutine_sync
 
 logger = get_logger("web-loader")
 
@@ -460,7 +461,7 @@ class ChromiumLoader:
         )
 
         for url in self.urls:
-            html_content = asyncio.run(scraping_fn(url))
+            html_content = run_coroutine_sync(scraping_fn(url))
             metadata = {"source": url}
             yield Document(page_content=html_content, metadata=metadata)
 

--- a/scrapegraphai/nodes/generate_answer_from_image_node.py
+++ b/scrapegraphai/nodes/generate_answer_from_image_node.py
@@ -8,6 +8,7 @@ from typing import List, Optional
 
 import aiohttp
 
+from ..utils.event_loop import run_coroutine_sync
 from .base_node import BaseNode
 
 
@@ -113,15 +114,4 @@ class GenerateAnswerFromImageNode(BaseNode):
         """
         Wrapper to run the asynchronous execute_async function in a synchronous context.
         """
-        try:
-            eventloop = asyncio.get_event_loop()
-        except RuntimeError:
-            eventloop = None
-
-        if eventloop and eventloop.is_running():
-            task = eventloop.create_task(self.execute_async(state))
-            state = eventloop.run_until_complete(asyncio.gather(task))[0]
-        else:
-            state = asyncio.run(self.execute_async(state))
-
-        return state
+        return run_coroutine_sync(self.execute_async(state))

--- a/scrapegraphai/nodes/graph_iterator_node.py
+++ b/scrapegraphai/nodes/graph_iterator_node.py
@@ -8,6 +8,7 @@ from typing import List, Optional, Type
 from pydantic import BaseModel
 from tqdm.asyncio import tqdm
 
+from ..utils.event_loop import run_coroutine_sync
 from .base_node import BaseNode
 
 DEFAULT_BATCHSIZE = 16
@@ -66,15 +67,7 @@ class GraphIteratorNode(BaseNode):
             f"--- Executing {self.node_name} Node with batchsize {batchsize} ---"
         )
 
-        try:
-            eventloop = asyncio.get_event_loop()
-        except RuntimeError:
-            eventloop = None
-
-        if eventloop and eventloop.is_running():
-            state = eventloop.run_until_complete(self._async_execute(state, batchsize))
-        else:
-            state = asyncio.run(self._async_execute(state, batchsize))
+        state = run_coroutine_sync(self._async_execute(state, batchsize))
 
         return state
 

--- a/scrapegraphai/utils/__init__.py
+++ b/scrapegraphai/utils/__init__.py
@@ -19,6 +19,7 @@ from .code_error_correction import (
 from .convert_to_md import convert_to_md
 from .data_export import export_to_csv, export_to_json, export_to_xml
 from .dict_content_compare import are_content_equal
+from .event_loop import run_coroutine_sync
 from .llm_callback_manager import CustomLLMCallbackManager
 from .logging import (
     get_logger,
@@ -86,6 +87,7 @@ __all__ = [
     "dynamic_import",
     "srcfile_import",
     "num_tokens_calculus",
+    "run_coroutine_sync",
     # Proxy handling
     "Proxy",
     "parse_or_search_proxy",

--- a/scrapegraphai/utils/event_loop.py
+++ b/scrapegraphai/utils/event_loop.py
@@ -1,0 +1,31 @@
+"""
+Event loop helper module
+"""
+
+import asyncio
+from concurrent.futures import ThreadPoolExecutor
+
+
+def run_coroutine_sync(coro):
+    """
+    Runs a coroutine from synchronous code.
+
+    Uses asyncio.run() when the current thread has no running event loop.
+    When called from code that already has one (Jupyter, FastAPI, and
+    similar environments), the coroutine runs on its own loop in a worker
+    thread, since asyncio.run() and loop.run_until_complete() both raise
+    RuntimeError in that case.
+
+    Args:
+        coro: The coroutine to execute.
+
+    Returns:
+        The value returned by the coroutine.
+    """
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(coro)
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        return executor.submit(asyncio.run, coro).result()


### PR DESCRIPTION
Fixes #1116.

Adds `scrapegraphai/utils/event_loop.py` with one helper, `run_coroutine_sync`: it uses `asyncio.run()` when no loop is running, and otherwise executes the coroutine on its own loop in a worker thread, since both `asyncio.run()` and `run_until_complete()` raise inside a running loop. The four crash sites now use it: `ChromiumLoader.lazy_load`, `browser_base_fetch`, `GraphIteratorNode.execute` and `GenerateAnswerFromImageNode.execute`. The two nodes had the check inverted, calling `run_until_complete` precisely when the loop was running. The worker thread follows the same idea as `AbstractGraph.run_safe_async`, which already offloads the blocking call to an executor. Plain scripts are unchanged: with no running loop the path is still a direct `asyncio.run()` on the calling thread.

Verified on Windows with Python 3.12: a real Playwright fetch through `ChromiumLoader.load()` from inside `asyncio.run(...)` now returns the page instead of raising, same for `GraphIteratorNode` and `GenerateAnswerFromImageNode` (the latter also no longer leaks a cancelled-task traceback), exceptions raised inside coroutines reach the caller unchanged, and the nine test files CI runs pass before and after (66 passed both times). Note on #1087: it refactors the scraping_fn selection a few lines above this change inside lazy_load; if it lands first I will rebase, the overlap is trivial. Happy to add a mocked unit test for the helper and register it in test-suite.yml if you want one.
