### PR TITLE
fix(telemetry): honor the SCRAPEGRAPHAI_TELEMETRY_ENABLED env var

### DIFF
--- a/scrapegraphai/telemetry/telemetry.py
+++ b/scrapegraphai/telemetry/telemetry.py
@@ -44,13 +44,11 @@ def _check_config_and_environ_for_telemetry_flag(default_value: bool, config_obj
         except Exception:
             pass
 
-    if os.environ.get("SCRAPEGRAPHAI_TELEMETRY_ENABLED") is not None:
-        try:
-            telemetry_enabled = config_obj.getboolean(
-                "DEFAULT", "telemetry_enabled"
-            )
-        except Exception:
-            pass
+    env_value = os.environ.get("SCRAPEGRAPHAI_TELEMETRY_ENABLED")
+    if env_value is not None:
+        env_value = env_value.strip().lower()
+        if env_value in configparser.ConfigParser.BOOLEAN_STATES:
+            telemetry_enabled = configparser.ConfigParser.BOOLEAN_STATES[env_value]
 
     return telemetry_enabled
 


### PR DESCRIPTION
Fixes #1118.

`_check_config_and_environ_for_telemetry_flag` re-read the config file inside the env var branch, so the opt-out documented in the README never had any effect. The branch now parses the variable's value with the same true/false strings configparser accepts (1/yes/true/on, 0/no/false/off, any casing). The env var wins over the config file since it is the more explicit setting, and unrecognized values keep the default instead of raising, matching how the config path already behaves.

Verified by importing the package in a subprocess for each value: false, False, FALSE, 0, no and off now disable telemetry, true, 1, yes and on keep it enabled, unset keeps the current default, and a config file value is still honored when the variable is not set. The nine test files that CI runs pass before and after the change. Happy to add a small unit test for this function and register it in test-suite.yml if you want one.
