### PR TITLE
docs: fix broken MiniMax link in README (docs/minimax.md 404s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ There are other pipelines that can be used to extract information from multiple 
 
 For each of these graphs there is the multi version. It allows to make calls of the LLM in parallel.
 
-It is possible to use different LLM through APIs, such as **OpenAI**, **Groq**, **Azure**, **Gemini**, **[MiniMax](docs/minimax.md)** and more, or local models using **Ollama**.
+It is possible to use different LLM through APIs, such as **OpenAI**, **Groq**, **Azure**, **Gemini**, **MiniMax** and more, or local models using **Ollama**.
 
 Remember to have [Ollama](https://ollama.com/) installed and download the models using the **ollama pull** command, if you want to use local models.
 


### PR DESCRIPTION
The **MiniMax** provider in the README links to `docs/minimax.md`, which returns a **404** — no such file exists in the repo (docs were moved off-repo in #1067).

On the same line, the sibling providers (`**OpenAI**`, `**Groq**`, `**Azure**`, `**Gemini**`) are plain bold with no link, and the translated READMEs already render MiniMax de-linked:
- `docs/italian.md:154` — `... **Gemini**, **MiniMax** e altri ...`
- `docs/spanish.md:157` — `... **Gemini**, **MiniMax** y más ...`

This de-links MiniMax in the English README to match, fixing the dead link. Docs-only, no functional change.
