### PR TITLE
fix: accept JSON schemas in structured output parser

### DIFF
--- a/scrapegraphai/utils/output_parser.py
+++ b/scrapegraphai/utils/output_parser.py
@@ -5,8 +5,8 @@ Functions to retrieve the correct output parser and format instructions for the 
 from typing import Any, Callable, Dict, List, Type, Union
 
 from langchain_core.exceptions import OutputParserException
-from langchain_core.outputs import Generation
 from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.outputs import Generation
 from pydantic import BaseModel as BaseModelV2
 from pydantic.v1 import BaseModel as BaseModelV1
 
@@ -58,6 +58,9 @@ def get_structured_output_parser(
     Returns:
         Callable: The output parser function.
     """
+    if isinstance(schema, dict):
+        return _dict_output_parser
+
     if issubclass(schema, BaseModelV1):
         return _base_model_v1_output_parser
 

--- a/tests/utils/output_parser_test.py
+++ b/tests/utils/output_parser_test.py
@@ -5,6 +5,7 @@ import pytest
 from scrapegraphai.utils.output_parser import (
     TolerantJsonOutputParser,
     _strip_doubled_braces,
+    get_structured_output_parser,
 )
 
 
@@ -20,6 +21,19 @@ def test_strip_doubled_braces_is_noop_for_clean_json():
 def test_strip_doubled_braces_ignores_unbalanced():
     text = '{{"content": "hi"}'
     assert _strip_doubled_braces(text) == text
+
+
+def test_structured_output_parser_accepts_json_schema():
+    schema = {
+        "title": "Person",
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+    }
+    output = {"name": "Ada"}
+
+    parser = get_structured_output_parser(schema)
+
+    assert parser(output) == output
 
 
 def test_tolerant_parser_parses_clean_json_unchanged():


### PR DESCRIPTION
## Summary

- Fixes: Passing a supported JSON Schema dictionary into structured-output generation raises TypeError before any model request instead of parsing the returned dictionary.
- Root cause: get_structured_output_parser documents and types dictionaries as valid schemas but calls the class-only issubclass builtin before dispatching dictionary schemas to _dict_output_parser.

## Regression evidence

- Before: `PYTHONDONTWRITEBYTECODE=1 uv run --frozen pytest -o addopts='' -p no:cacheprovider tests/utils/output_parser_test.py::test_structured_output_parser_accepts_json_schema -q` exited `1`

- After: `PYTHONDONTWRITEBYTECODE=1 uv run --frozen pytest -o addopts='' -p no:cacheprovider tests/utils/output_parser_test.py::test_structured_output_parser_accepts_json_schema -q` exited `0`

## Verification

- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -o addopts='' -p no:cacheprovider tests/utils/output_parser_test.py -q`
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/pytest -o addopts='' -p no:cacheprovider tests/test_json_scraper_graph.py -q`
- `.venv/bin/ruff check scrapegraphai/utils/output_parser.py tests/utils/output_parser_test.py`
- `.venv/bin/black --check scrapegraphai/utils/output_parser.py tests/utils/output_parser_test.py`
- `.venv/bin/isort --check-only scrapegraphai/utils/output_parser.py tests/utils/output_parser_test.py`
- `uv build --no-sources`
- `offline ChatOpenAI.with_structured_output JSON Schema contract check`

## Scope

- 2 files changed, +18 / -1 lines

## Local full-suite note

I also attempted the repository CI selection, `uv run pytest tests/ -m "unit or not integration"`. It reached 95% with unrelated live-provider, browser, network, and existing assertion failures, then was interrupted when an external proxy request stalled. The deterministic affected suites listed above pass.
