### PR TITLE
fix(graph): expose when the 8192 token fallback was used

### DIFF
--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -64,6 +64,9 @@ class AbstractGraph(ABC):
         self.source = source
         self.config = config
         self.schema = schema
+        # Set to True when no token limit is known for the configured model and
+        # the 8192 fallback is used; see _create_llm.
+        self.model_tokens_defaulted = False
         self.llm_model = self._create_llm(config["llm"])
         self.verbose = False if config is None else config.get("verbose", False)
         self.headless = True if self.config is None else config.get("headless", True)
@@ -218,6 +221,12 @@ class AbstractGraph(ABC):
                     llm_params["model"],
                 )
                 self.model_token = 8192
+                # A silent 8192 window truncates long pages and changes the
+                # answer without failing. The log line alone is not reachable
+                # from the returned object, so callers that batch runs (or
+                # capture stdout only) have no way to tell a real limit from
+                # the fallback. Record it so it can be asserted on.
+                self.model_tokens_defaulted = True
         else:
             self.model_token = llm_params["model_tokens"]
 

--- a/tests/graphs/abstract_graph_test.py
+++ b/tests/graphs/abstract_graph_test.py
@@ -32,6 +32,61 @@ def test_llm_missing_tokens(monkeypatch, capsys):
     assert "Max input tokens for model" in captured
 
 
+def test_llm_missing_tokens_sets_defaulted_flag(monkeypatch):
+    """An unknown model must record that the 8192 window is a fallback.
+
+    The warning is only a log line, so a caller reading ``model_token`` sees
+    8192 and cannot tell whether that is the model's real limit or the
+    default. A silent 8192 window truncates long pages and changes the answer
+    without failing, which is the failure mode reported in #1121.
+    """
+    from scrapegraphai.graphs import abstract_graph
+
+    monkeypatch.setattr(
+        abstract_graph, "models_tokens", {"openai": {"gpt-3.5-turbo": 4096}}
+    )
+    llm_config = {"model": "openai/not-known-model", "openai_api_key": "test"}
+    with patch.object(TestGraph, "_create_graph", return_value=Mock(nodes=[])):
+        graph = TestGraph("Test prompt", {"llm": llm_config})
+
+    assert graph.model_token == 8192
+    assert graph.model_tokens_defaulted is True
+
+
+def test_known_model_does_not_set_defaulted_flag(monkeypatch):
+    """A model with a known limit must not be flagged as defaulted."""
+    from scrapegraphai.graphs import abstract_graph
+
+    monkeypatch.setattr(
+        abstract_graph, "models_tokens", {"openai": {"gpt-3.5-turbo": 4096}}
+    )
+    llm_config = {"model": "openai/gpt-3.5-turbo", "openai_api_key": "test"}
+    with patch.object(TestGraph, "_create_graph", return_value=Mock(nodes=[])):
+        graph = TestGraph("Test prompt", {"llm": llm_config})
+
+    assert graph.model_token == 4096
+    assert graph.model_tokens_defaulted is False
+
+
+def test_explicit_model_tokens_does_not_set_defaulted_flag(monkeypatch):
+    """An explicit model_tokens is authoritative, not a fallback."""
+    from scrapegraphai.graphs import abstract_graph
+
+    monkeypatch.setattr(
+        abstract_graph, "models_tokens", {"openai": {"gpt-3.5-turbo": 4096}}
+    )
+    llm_config = {
+        "model": "openai/not-known-model",
+        "openai_api_key": "test",
+        "model_tokens": 1000000,
+    }
+    with patch.object(TestGraph, "_create_graph", return_value=Mock(nodes=[])):
+        graph = TestGraph("Test prompt", {"llm": llm_config})
+
+    assert graph.model_token == 1000000
+    assert graph.model_tokens_defaulted is False
+
+
 def test_burr_kwargs():
     """Test that burr_kwargs configuration correctly sets use_burr and burr_config on the graph."""
     dummy_graph = Mock()


### PR DESCRIPTION
Relates to #1121.

## Verified the report against `main` (`27d9d28`)

Three graphs instantiated with a model that isn't in `models_tokens`:

```
graph 0: model_token = 8192
graph 1: model_token = 8192
graph 2: model_token = 8192

control (openai/gpt-3.5-turbo): model_token = 4096
```

So the silent 8192 fallback is real, and it is the important part of the report: a run succeeds, the JSON validates, and the model simply never saw the truncated portion of the page.

**One correction to the report**, since it affects what needs fixing: the warning is *not* emitted once per process. `warning_once` exists in `scrapegraphai/utils/logging.py` but `_create_llm` calls plain `logger.warning`, so it fires on **every** graph construction — I captured 3 emissions from 3 instantiations. So the "long job warns on the first URL and stays silent afterwards" mechanism isn't what's happening; the warning is there every time, it's just a log record.

That makes option 2 from the report the right shape rather than the once-per-process fix.

## What this PR does

Records the fallback on the graph so it is reachable from code:

```python
self.model_tokens_defaulted = False   # set in __init__
...
except KeyError:
    logger.warning(...)
    self.model_token = 8192
    self.model_tokens_defaulted = True
```

Before this, a caller reading `model_token` saw `8192` and had no way to tell whether that was the model's real limit or the default — I confirmed there was no attribute anywhere on the instance recording it. Now a batch pipeline can fail fast on its own terms:

```python
graph = SmartScraperGraph(prompt=..., source=..., config=cfg)
if graph.model_tokens_defaulted:
    raise RuntimeError(f"no known token limit for {cfg['llm']['model']}; set model_tokens")
```

## Why not raise (option 1)

The report's first preference is to raise outright. I didn't do that here because it changes behavior for every existing user of an unlisted model — including local/self-hosted and newly-released models, which are exactly the cases most likely to be missing from the table. That's a maintainer call on breakage, and it can be layered on top of this cheaply (a `strict_model_tokens` config flag reading the same state) once the state exists. Happy to follow up with that if you'd prefer it.

I also didn't thread this into `execution_info`, since that object is produced by the graph executor rather than the graph, so surfacing it there is a larger change than the defect warrants.

## Tests

Three added to `tests/graphs/abstract_graph_test.py`, alongside the existing `test_llm_missing_tokens`:

- `test_llm_missing_tokens_sets_defaulted_flag` — unknown model sets the flag
- `test_known_model_does_not_set_defaulted_flag` — known model does not
- `test_explicit_model_tokens_does_not_set_defaulted_flag` — an explicit `model_tokens` is authoritative, not a fallback

## Verification

- `pytest tests/graphs/abstract_graph_test.py`: **24 passed, 1 failed** (21 passed, 1 failed on unmodified `main` — so +3 and no regressions).
- The one failure is pre-existing: `test_llm_missing_tokens` asserts the warning appears in `capsys` stdout, but the message goes to the logger, so `captured.out` is empty. It fails identically before and after this change. It's arguably the same underlying complaint as #1121 — the warning isn't where callers look — but fixing that test is a separate change and I left it alone.
- Mutation-checked: removing only the `self.model_tokens_defaulted = True` line fails exactly `test_llm_missing_tokens_sets_defaulted_flag` while the other two still pass.
