### PR TITLE
docs: fix timeout documentation links

### DIFF
--- a/docs/timeout_configuration.md
+++ b/docs/timeout_configuration.md
@@ -287,6 +287,6 @@ node_config = {
 
 ## See Also
 
-- [FetchNode API Documentation](../api/nodes/fetch_node.md)
-- [Graph Configuration](./graph_configuration.md)
-- [Error Handling](./error_handling.md)
+- [FetchNode source](../scrapegraphai/nodes/fetch_node.py)
+- [Graph examples](#graph-examples)
+- [Timeout handling best practices](#best-practices)


### PR DESCRIPTION
## Summary

- Link the timeout guide to the existing `FetchNode` source file.
- Replace links to two missing pages with relevant sections in the same guide.

## Validation

- Verified that the source file and both in-page anchors exist.
- Ran `git diff --check`.
