### PR TITLE
docs: add NodeMaven sponsor to all README languages

### DIFF
--- a/docs/chinese.md
+++ b/docs/chinese.md
@@ -158,6 +158,12 @@ print(json.dumps(result, indent=4))
 
 ScrapeGraphAI 的文档可以在[这里](https://docs.scrapegraphai.com/introduction)找到。
 
+## 🏆 赞助商
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+ScrapeGraphAI 用户优惠码：`SCRAPEGRAPH35`（移动和住宅代理 35% 折扣），`SCRAPEGRAPH40`（ISP / 静态代理 40% 折扣）。
+
 ## 🤝 贡献
 
 欢迎贡献并加入我们的 Discord 服务器与我们讨论改进和提出建议！

--- a/docs/french.md
+++ b/docs/french.md
@@ -160,6 +160,12 @@ N'oubliez pas d'installer [Ollama](https://ollama.com/) et de télécharger les 
 
 La documentation pour ScrapeGraphAI se trouve [ici](https://docs.scrapegraphai.com/introduction).
 
+## 🏆 Sponsors
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+Codes pour les utilisateurs de ScrapeGraphAI : `SCRAPEGRAPH35` (35 % sur les proxies mobile et résidentiels), `SCRAPEGRAPH40` (40 % sur les proxies ISP / statiques).
+
 ## 🤝 Contribuer
 
 N'hésitez pas à contribuer et à rejoindre notre serveur Discord pour discuter avec nous des améliorations et nous donner des suggestions !

--- a/docs/german.md
+++ b/docs/german.md
@@ -160,6 +160,12 @@ Denken Sie daran, [Ollama](https://ollama.com/) installiert zu haben und die Mod
 
 Die Dokumentation zu ScrapeGraphAI finden Sie [hier](https://docs.scrapegraphai.com/introduction).
 
+## 🏆 Sponsoren
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+Codes für ScrapeGraphAI-Nutzer: `SCRAPEGRAPH35` (35 % auf Mobile- und Residential-Proxys), `SCRAPEGRAPH40` (40 % auf ISP- / Static-Proxys).
+
 ## 🤝 Mitwirken
 
 Fühlen Sie sich frei, beizutragen und treten Sie unserem Discord-Server bei, um mit uns über Verbesserungen zu diskutieren und uns Vorschläge zu machen!

--- a/docs/italian.md
+++ b/docs/italian.md
@@ -162,6 +162,12 @@ Ricordati di avere [Ollama](https://ollama.com/) installato e di scaricare i mod
 La documentazione di ScrapeGraphAI è disponibile [qui](https://scrapegraph-ai.readthedocs.io/en/latest/).
 Consulta anche il Docusaurus [qui](https://docs-oss.scrapegraphai.com/).
 
+## 🏆 Sponsor
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+Codici per gli utenti ScrapeGraphAI: `SCRAPEGRAPH35` (35% su proxy mobile e residenziali), `SCRAPEGRAPH40` (40% su proxy ISP / statici).
+
 ## 🤝 Vuoi contribuire?
 
 Sentiti libero di contribuire e unisciti al nostro server Discord per discutere con noi su cosa migliorare e darci suggerimenti!

--- a/docs/japanese.md
+++ b/docs/japanese.md
@@ -158,6 +158,12 @@ print(json.dumps(result, indent=4))
 
 ScrapeGraphAIのドキュメントは[こちら](https://docs.scrapegraphai.com/introduction)で見ることができます。
 
+## 🏆 スポンサー
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+ScrapeGraphAI ユーザー向けコード：`SCRAPEGRAPH35`（モバイル / 住宅用プロキシ 35% オフ）、`SCRAPEGRAPH40`（ISP / 静的プロキシ 40% オフ）。
+
 ## 🤝 貢献
 
 貢献を歓迎し、Discordサーバーで改善や提案について話し合います！

--- a/docs/korean.md
+++ b/docs/korean.md
@@ -158,6 +158,12 @@ OpenAI, Groq, Azure, Gemini와 같은 API를 통해 다양한 LLM을 사용할 �
 
 ScrapeGraphAI 관련 문서는 [여기](https://docs.scrapegraphai.com/introduction)에서 확인하실 수 있습니다.
 
+## 🏆 스폰서
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+ScrapeGraphAI 사용자 코드: `SCRAPEGRAPH35` (모바일 및 주거용 프록시 35% 할인), `SCRAPEGRAPH40` (ISP / 고정 프록시 40% 할인).
+
 ## 🤝 기여
 
 자유롭게 기여하고 Discord 서버에 참여하여 개선 사항을 논의하고 제안해 주세요!

--- a/docs/portuguese.md
+++ b/docs/portuguese.md
@@ -158,6 +158,12 @@ Lembre-se de ter o [Ollama](https://ollama.com/) instalado e baixar os modelos u
 
 A documentação do ScrapeGraphAI pode ser encontrada [aqui](https://docs.scrapegraphai.com/introduction).
 
+## 🏆 Patrocinadores
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+Códigos para usuários do ScrapeGraphAI: `SCRAPEGRAPH35` (35% em proxies móveis e residenciais), `SCRAPEGRAPH40` (40% em proxies ISP / estáticos).
+
 ## 🤝 Contribuindo
 
 Sinta-se à vontade para contribuir e junte-se ao nosso servidor Discord para discutir melhorias e nos dar sugestões!

--- a/docs/russian.md
+++ b/docs/russian.md
@@ -158,6 +158,12 @@ print(json.dumps(result, indent=4))
 
 Документация для ScrapeGraphAI доступна [здесь](https://docs.scrapegraphai.com/introduction).
 
+## 🏆 Спонсоры
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+Коды для пользователей ScrapeGraphAI: `SCRAPEGRAPH35` (скидка 35% на mobile и residential-прокси), `SCRAPEGRAPH40` (скидка 40% на ISP / static-прокси).
+
 ## 🤝 Участие
 
 Не стесняйтесь вносить свой вклад и присоединяйтесь к нашему серверу Discord, чтобы обсудить с нами улучшения и дать нам предложения!

--- a/docs/spanish.md
+++ b/docs/spanish.md
@@ -165,6 +165,12 @@ Recuerda tener [Ollama](https://ollama.com/) instalado y descargar los modelos c
 
 La documentación de ScrapeGraphAI está disponible [aquí](https://docs.scrapegraphai.com/introduction).
 
+## 🏆 Patrocinadores
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+Códigos para usuarios de ScrapeGraphAI: `SCRAPEGRAPH35` (35% en proxies móviles y residenciales), `SCRAPEGRAPH40` (40% en proxies ISP / estáticos).
+
 ## 🤝 Contribuciones
 
 ¡Siéntete libre de contribuir y únete a nuestro servidor de Discord para discutir mejoras y compartir sugerencias!

--- a/docs/turkish.md
+++ b/docs/turkish.md
@@ -159,6 +159,12 @@ Yerel modelleri kullanmak istiyorsanız, [Ollama](https://ollama.com/) kurulu ol
 
 ScrapeGraphAI dokümantasyonuna [buradan](https://docs.scrapegraphai.com/introduction) ulaşabilirsiniz.
 
+## 🏆 Sponsorlar
+
+[![NodeMaven](assets/nodemaven-banner.png)](https://go.nodemaven.com/scrapegraphyai)
+
+ScrapeGraphAI kullanıcıları için kodlar: `SCRAPEGRAPH35` (mobil ve residential proxy'lerde %35 indirim), `SCRAPEGRAPH40` (ISP / static proxy'lerde %40 indirim).
+
 ## 🤝 Katkıda Bulunun
 
 Projeye katkıda bulunmaktan çekinmeyin ve geliştirmeleri tartışmak ve bize önerilerde bulunmak için Discord sunucumuza katılın!


### PR DESCRIPTION
## Summary
- Add the NodeMaven sponsor block to all 10 language README translations (`docs/{chinese,japanese,korean,russian,turkish,german,spanish,french,portuguese,italian}.md`).
- Same banner (`assets/nodemaven-banner.png` from `docs/`), tracking link (`https://go.nodemaven.com/scrapegraphyai`), and codes (`SCRAPEGRAPH35` / `SCRAPEGRAPH40`), with heading + codes sentence translated to match each file.
- English `README.md` already has this section and is unchanged.

## Test plan
- [ ] Confirm each language file inserts the sponsor section immediately before the 🤝 Contributing heading
- [ ] Confirm banner images resolve from `docs/` via `assets/nodemaven-banner.png`
- [ ] Confirm tracking URL and discount codes are unchanged
- [ ] Confirm English README.md is untouched