### PR TITLE
fix(graph): report the effective token window in execution info

### DIFF
--- a/scrapegraphai/graphs/abstract_graph.py
+++ b/scrapegraphai/graphs/abstract_graph.py
@@ -78,6 +78,14 @@ class AbstractGraph(ABC):
         self.timeout = self.config.get("timeout", 480)
 
         self.graph = self._create_graph()
+        # Report the token window through the execution info as well. The
+        # warning emitted for an unknown model only reaches stderr, which is
+        # lost in batch and async contexts, so a caller had no way to tell a
+        # truncating 8192 fallback from a real limit by looking at the result.
+        # _create_llm is overridable and does not set model_token on every
+        # path, so fall back to the defaults BaseGraph already declares.
+        self.graph.model_token = getattr(self, "model_token", None)
+        self.graph.model_tokens_defaulted = self.model_tokens_defaulted
         self.final_state = None
         self.execution_info = None
 
@@ -318,6 +326,13 @@ class AbstractGraph(ABC):
     def get_execution_info(self):
         """
         Returns the execution information of the graph.
+
+        The final "TOTAL RESULT" entry also carries the token window the run
+        actually used: ``effective_model_tokens`` and ``model_tokens_defaulted``,
+        the latter being True when no limit was known for the configured model
+        and the 8192 fallback was applied. A defaulted window chunks long pages
+        and can change the answer without raising, so batch callers should check
+        this flag rather than rely on the warning logged to stderr.
 
         Returns:
             dict: The execution information of the graph.

--- a/scrapegraphai/graphs/base_graph.py
+++ b/scrapegraphai/graphs/base_graph.py
@@ -69,6 +69,12 @@ class BaseGraph:
         self.graph_name = graph_name
         self.initial_state = {}
         self.callback_manager = CustomLLMCallbackManager()
+        # Effective input-token window used to chunk documents, and whether it
+        # is the 8192 fallback rather than the model's real limit. AbstractGraph
+        # fills these in after building the graph; they are reported in the
+        # "TOTAL RESULT" entry of the execution info (see #1121).
+        self.model_token = None
+        self.model_tokens_defaulted = False
 
         if nodes[0].node_name != entry_point.node_name:
             warnings.warn(
@@ -316,6 +322,8 @@ class BaseGraph:
                 "successful_requests": cb_total["successful_requests"],
                 "total_cost_USD": cb_total["total_cost_USD"],
                 "exec_time": total_exec_time,
+                "effective_model_tokens": self.model_token,
+                "model_tokens_defaulted": self.model_tokens_defaulted,
             }
         )
 

--- a/tests/graphs/abstract_graph_test.py
+++ b/tests/graphs/abstract_graph_test.py
@@ -369,3 +369,79 @@ class TestAbstractGraph:
         graph.execution_info = dummy_info
         info = graph.get_execution_info()
         assert info == dummy_info
+
+
+class _StubNode:
+    """Minimal node used to drive BaseGraph without any model or network call."""
+
+    def __init__(self, node_name="Stub"):
+        self.node_name = node_name
+        self.node_type = "node"
+        self.node_config = {}
+
+    def execute(self, state):
+        return state
+
+
+def _run_stub_graph(model_token, model_tokens_defaulted):
+    """Executes a one-node graph and returns its "TOTAL RESULT" entry."""
+    stub = _StubNode()
+    graph = BaseGraph(nodes=[stub], edges=[], entry_point=stub)
+    graph.model_token = model_token
+    graph.model_tokens_defaulted = model_tokens_defaulted
+
+    with patch("scrapegraphai.graphs.base_graph.log_graph_execution"):
+        _, exec_info = graph.execute({})
+
+    return next(entry for entry in exec_info if entry["node_name"] == "TOTAL RESULT")
+
+
+def test_execution_info_reports_defaulted_token_window():
+    """The 8192 fallback must be visible in the returned execution info.
+
+    Reported in #1121: the warning for an unknown model goes to stderr, so it
+    is lost in batch, worker and async contexts. A caller that only has the
+    returned object could not tell a truncating 8192 window from a real limit.
+    """
+    total = _run_stub_graph(8192, True)
+
+    assert total["effective_model_tokens"] == 8192
+    assert total["model_tokens_defaulted"] is True
+
+
+def test_execution_info_reports_known_token_window():
+    """A model with a known limit is reported without the defaulted flag."""
+    total = _run_stub_graph(1000000, False)
+
+    assert total["effective_model_tokens"] == 1000000
+    assert total["model_tokens_defaulted"] is False
+
+
+def test_abstract_graph_propagates_defaulted_token_window(monkeypatch):
+    """AbstractGraph hands the token window to the graph it builds."""
+    from scrapegraphai.graphs import abstract_graph
+
+    monkeypatch.setattr(
+        abstract_graph, "models_tokens", {"openai": {"gpt-3.5-turbo": 4096}}
+    )
+    llm_config = {"model": "openai/not-known-model", "openai_api_key": "test"}
+    with patch.object(TestGraph, "_create_graph", return_value=Mock(nodes=[])):
+        graph = TestGraph("Test prompt", {"llm": llm_config})
+
+    assert graph.graph.model_token == 8192
+    assert graph.graph.model_tokens_defaulted is True
+
+
+def test_abstract_graph_propagates_known_token_window(monkeypatch):
+    """A known model is propagated with the defaulted flag left off."""
+    from scrapegraphai.graphs import abstract_graph
+
+    monkeypatch.setattr(
+        abstract_graph, "models_tokens", {"openai": {"gpt-3.5-turbo": 4096}}
+    )
+    llm_config = {"model": "openai/gpt-3.5-turbo", "openai_api_key": "test"}
+    with patch.object(TestGraph, "_create_graph", return_value=Mock(nodes=[])):
+        graph = TestGraph("Test prompt", {"llm": llm_config})
+
+    assert graph.graph.model_token == 4096
+    assert graph.graph.model_tokens_defaulted is False


### PR DESCRIPTION
Part of #1121.

When a model isn't in `models_tokens`, `_create_llm` falls back to an 8192 token window. That value becomes the `chunk_size` used for splitting, so on a long page the model never sees the part that mattered. The run still succeeds and the JSON still validates, so the answer just comes back wrong.

The only signal today is a `logger.warning` on stderr. That gets lost in batch jobs, workers and anything async, so if all you have is the returned object, you can't tell a truncating fallback from a model whose real limit happens to be 8192.

#1126 exposed this as `graph.model_tokens_defaulted`. Suggestion (2) in the issue asked for it in the result itself, so downstream code can check it per run without reaching into the graph object. This PR does that half.

### What changed

Two new keys in the `"TOTAL RESULT"` entry of the execution info:

* `effective_model_tokens`: the input token window the run actually used for chunking
* `model_tokens_defaulted`: true when no limit was known and the 8192 fallback kicked in

```python
result = graph.run()
total = graph.get_execution_info()[-1]

total["effective_model_tokens"]   # 8192
total["model_tokens_defaulted"]   # True, so the answer may be truncated
```

How it's wired:

* `BaseGraph.__init__` declares `model_token = None` and `model_tokens_defaulted = False`.
* `AbstractGraph.__init__` passes both to the graph right after `_create_graph()`, so every graph picks them up without per-graph changes. `_create_llm` can be overridden and doesn't set `model_token` on every path, so it reads through `getattr`.
* `_execute_standard` adds the two keys to the `"TOTAL RESULT"` entry.
* `get_execution_info` documents them.

Existing keys are untouched, so anything already reading that entry keeps working.

### Tests

Four in `tests/graphs/abstract_graph_test.py`, next to the ones from #1126:

* the defaulted window shows up in `"TOTAL RESULT"`
* a known window shows up without the flag
* `AbstractGraph` propagates a defaulted window to its graph
* `AbstractGraph` propagates a known window with the flag off

### What I ran

`uv run pytest` over the same unit suite as `.github/workflows/test-suite.yml`: 95 passed.

`ruff check` and `isort --check-only` are clean on the files I touched. `black --check` is clean on my changes, but it also wants to reformat the `CLICKABLE_URL` constant at the top of `base_graph.py`. That one predates this PR and AGENTS.md says not to reformat untouched files, so I left it alone. Happy to fold it in if you'd rather.

Two tests already fail on `pre/beta` before my changes: `test_llm_missing_tokens` and `test_script_creator_multi_graph.py::test_entry_point_node`. I checked both on a clean checkout, didn't touch either, and neither one runs in CI.

No dependency changes, so `uv.lock` is untouched.

### The rest of #1121

(4) landed in #1140. (1), raising instead of defaulting, is the breaking option and isn't in here. If that's the direction you want, or an opt-in strict flag, I can do it as a follow-up.

Fixes #1121
