### PR TITLE
fix(fetch): pass the correct baseurl to convert_to_md, fix undefined document in use_soup path

### DIFF
--- a/scrapegraphai/nodes/fetch_node.py
+++ b/scrapegraphai/nodes/fetch_node.py
@@ -293,19 +293,26 @@ class FetchNode(BaseNode):
 
                 if not self.cut:
                     parsed_content = cleanup_html(response, source)
+                else:
+                    parsed_content = response.text
 
                 if (
                     isinstance(self.llm_model, (ChatOpenAI, AzureChatOpenAI))
                     and not self.script_creator
                     or (self.force and not self.script_creator)
                 ):
-                    parsed_content = convert_to_md(source, parsed_content)
+                    parsed_content = convert_to_md(parsed_content, source)
 
+                document = [
+                    Document(page_content=response.text, metadata={"source": source})
+                ]
                 compressed_document = [Document(page_content=parsed_content)]
             else:
                 self.logger.warning(
                     f"Failed to retrieve contents from the webpage at url: {source}"
                 )
+                document = [Document(page_content="", metadata={"source": source})]
+                compressed_document = document
         else:
             loader_kwargs = {}
 
@@ -395,7 +402,7 @@ class FetchNode(BaseNode):
                 and not self.script_creator
                 and not self.openai_md_enabled
             ):
-                parsed_content = convert_to_md(document[0].page_content, parsed_content)
+                parsed_content = convert_to_md(document[0].page_content, source)
 
             compressed_document = [
                 Document(page_content=parsed_content, metadata={"source": "html file"})

--- a/tests/nodes/fetch_node_test.py
+++ b/tests/nodes/fetch_node_test.py
@@ -3,6 +3,54 @@ from langchain_core.documents import Document
 from scrapegraphai.nodes import FetchNode
 
 
+def test_fetch_html_convert_to_md_uses_source_as_baseurl(mocker):
+    """convert_to_md must receive the fetched page's URL as baseurl, not the HTML itself."""
+    content = "<html><body><a href='/relative'>link</a></body></html>"
+    mock_loader_cls = mocker.patch("scrapegraphai.nodes.fetch_node.ChromiumLoader")
+    mock_loader = mock_loader_cls.return_value
+    mock_loader.load.return_value = [Document(page_content=content)]
+    mock_convert = mocker.patch(
+        "scrapegraphai.nodes.fetch_node.convert_to_md", return_value="converted"
+    )
+
+    node = FetchNode(
+        input="url | local_dir",
+        output=["doc_content"],
+        node_config={"headless": False, "force": True},
+    )
+    source = "https://scrapegraph-ai.com/example"
+    result = node.execute({"url": source})
+
+    mock_convert.assert_called_once_with(content, source)
+    assert result["doc_content"][0].page_content == "converted"
+
+
+def test_fetch_html_use_soup_with_default_cut_does_not_raise(mocker):
+    """use_soup with the default cut=True must not raise UnboundLocalError and
+    must call convert_to_md with (html, source), not (source, html)."""
+    html = "<html><body><a href='/relative'>link</a></body></html>"
+    mock_response = mocker.Mock()
+    mock_response.status_code = 200
+    mock_response.text = html
+    mocker.patch(
+        "scrapegraphai.nodes.fetch_node.requests.get", return_value=mock_response
+    )
+    mock_convert = mocker.patch(
+        "scrapegraphai.nodes.fetch_node.convert_to_md", return_value="converted"
+    )
+
+    node = FetchNode(
+        input="url | local_dir",
+        output=["doc_content"],
+        node_config={"use_soup": True, "force": True},
+    )
+    source = "https://scrapegraph-ai.com/example"
+    result = node.execute({"url": source})
+
+    mock_convert.assert_called_once_with(html, source)
+    assert result["doc_content"][0].page_content == "converted"
+
+
 def test_fetch_html(mocker):
     title = "ScrapeGraph AI"
     link_url = "https://github.com/VinciGit00/Scrapegraph-ai"


### PR DESCRIPTION
## Summary
- FetchNode's Chromium-loader path called convert_to_md(document[0].page_content, parsed_content) with the same HTML value for both the html and baseurl arguments, so html2text prepended the entire document to every relative link's href, inflating model input by ~74x on pages with many relative links. Now passes the actual source URL as baseurl.
- The use_soup=True path had two related bugs in the same call: the html/url arguments were swapped, and parsed_content was referenced before assignment whenever cut=True (the default in every graph), raising UnboundLocalError.
- The use_soup=True path also never assigned the document variable that handle_web_source unconditionally writes to state, so that path crashed with UnboundLocalError on every request, success or failure. Fixed by assigning document in both the success and failure branches.

Fixes #1142

## Test plan
- [x] Added test_fetch_html_convert_to_md_uses_source_as_baseurl — asserts convert_to_md is called with (html, source) on the Chromium path.
- [x] Added test_fetch_html_use_soup_with_default_cut_does_not_raise — exercises use_soup=True with the default cut=True and asserts it no longer raises and calls convert_to_md with correct argument order.
- [x] uv run pytest tests/nodes/fetch_node_test.py passes.
- [x] uv run ruff check, uv run black --check, uv run isort --check-only pass on both changed files.